### PR TITLE
Set as Default Browser

### DIFF
--- a/electron/assets/Info.plist
+++ b/electron/assets/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDocumentTypes</key>
+  	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>PDF document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.adobe.pdf</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>HTML document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.html</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>XHTML document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.xhtml</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/electron/browser/browser.ts
+++ b/electron/browser/browser.ts
@@ -104,6 +104,13 @@ export class Browser extends TypedEventEmitter<BrowserEvents> {
   }
 
   /**
+   * Gets the focused window
+   */
+  public getFocusedWindow(): TabbedBrowserWindow | undefined {
+    return this.windowManager.getFocusedWindow();
+  }
+
+  /**
    * Gets a window by its ID
    */
   public getWindowById(windowId: number): TabbedBrowserWindow | undefined {

--- a/electron/browser/tabs/tab-context-menu.ts
+++ b/electron/browser/tabs/tab-context-menu.ts
@@ -31,7 +31,7 @@ export function createTabContextMenu(
 
       // Helper function to create a new tab
       const createNewTab = async (url: string, window?: TabbedBrowserWindow) => {
-        const sourceTab = await browser.tabs.createTab(profileId, window ? window.id : tabbedWindow.id, spaceId);
+        const sourceTab = await browser.tabs.createTab(window ? window.id : tabbedWindow.id, profileId, spaceId);
         sourceTab.loadURL(url);
         browser.tabs.setActiveTab(sourceTab);
       };

--- a/electron/browser/tabs/tab.ts
+++ b/electron/browser/tabs/tab.ts
@@ -321,7 +321,7 @@ export class Tab extends TypedEventEmitter<TabEvents> {
       windowId = newWindow.id;
     }
 
-    const newTab = this.tabManager.internalCreateTab(this.profileId, windowId, this.spaceId, constructorOptions);
+    const newTab = this.tabManager.internalCreateTab(windowId, this.profileId, this.spaceId, constructorOptions);
     newTab.loadURL(url);
 
     let glanced = false;

--- a/electron/browser/window-manager.ts
+++ b/electron/browser/window-manager.ts
@@ -55,6 +55,18 @@ export class WindowManager {
   }
 
   /**
+   * Gets the focused window
+   */
+  public getFocusedWindow(): TabbedBrowserWindow | undefined {
+    for (const window of this.windows.values()) {
+      if (window.window.isFocused()) {
+        return window;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Gets a window by its ID
    */
   public getWindowById(windowId: number): TabbedBrowserWindow | undefined {

--- a/electron/forge.config.ts
+++ b/electron/forge.config.ts
@@ -107,6 +107,18 @@ const config: ForgeConfig = {
         "**/node_modules/@img/**/*"
       ].join(",")
     },
+    extendInfo: "assets/Info.plist",
+    appCategoryType: "public.app-category.productivity",
+    protocols: [
+      {
+        name: "http URL",
+        schemes: ["http"]
+      },
+      {
+        name: "Secure http URL",
+        schemes: ["https"]
+      }
+    ],
     appBundleId: "dev.iamevan.flow",
     extraResource: [uiPath, "assets"],
     icon: "assets/AppIcon",

--- a/electron/ipc/app/new-tab.ts
+++ b/electron/ipc/app/new-tab.ts
@@ -35,7 +35,7 @@ export function openNewTab(tabbedBrowserWindow: TabbedBrowserWindow) {
       getSpace(spaceId).then(async (space) => {
         if (!space) return;
 
-        const tab = await tabManager.createTab(space.profileId, tabbedBrowserWindow.id, spaceId);
+        const tab = await tabManager.createTab(tabbedBrowserWindow.id, space.profileId, spaceId);
         tabManager.setActiveTab(tab);
       });
     }

--- a/electron/ipc/browser/tabs.ts
+++ b/electron/ipc/browser/tabs.ts
@@ -139,7 +139,7 @@ ipcMain.handle("tabs:new-tab", async (event, url?: string, isForeground?: boolea
   const space = await getSpace(spaceId);
   if (!space) return;
 
-  const tab = await tabManager.createTab(space.profileId, window.id, space.id);
+  const tab = await tabManager.createTab(window.id, space.profileId, space.id);
 
   if (url) {
     tab.loadURL(url);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The app can now open PDF, HTML, and XHTML documents directly on macOS.
  - The app is registered to handle HTTP and HTTPS links on macOS, allowing it to open web links from other apps.

- **Enhancements**
  - Improved logic for opening new tabs, ensuring a new tab opens automatically when the browser is ready and no tab groups exist.
  - Enhanced tab creation logic for greater flexibility and reliability when opening tabs in different windows or profiles.

- **Bug Fixes**
  - Standardized the order of parameters when creating new tabs, ensuring consistency and reducing potential errors.

- **Chores**
  - Updated macOS app metadata to categorize the app under productivity and support custom document types and URL schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->