### PR TITLE
Add Tab Popup Menu

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -192,6 +192,10 @@ const tabsAPI: FlowTabsAPI = {
     return ipcRenderer.invoke("tabs:close-tab", tabId);
   },
 
+  showContextMenu: async (tabId: number) => {
+    return ipcRenderer.send("tabs:show-context-menu", tabId);
+  },
+
   // Special Exception: This is allowed on every tab, but very tightly secured.
   // It will only work if the tab is currently in Picture-in-Picture mode.
   disablePictureInPicture: async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -192,7 +192,7 @@ const tabsAPI: FlowTabsAPI = {
     return ipcRenderer.invoke("tabs:close-tab", tabId);
   },
 
-  showContextMenu: async (tabId: number) => {
+  showContextMenu: (tabId: number) => {
     return ipcRenderer.send("tabs:show-context-menu", tabId);
   },
 

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -61,14 +61,21 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
     return isFocused ? "bg-white dark:bg-white/10" : "";
   };
 
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    flow.tabs.showContextMenu(tab.id);
+  };
+
   return (
     <MotionSidebarMenuButton
       key={tab.id}
       onClick={handleClick}
+      onContextMenu={handleContextMenu}
       className={cn(
         "hover:!bg-gray-200/60 dark:hover:!bg-white/5", // Simplified hover color
         getTabStyle(),
-        "text-gray-900 dark:text-gray-200"
+        "text-gray-900 dark:text-gray-200",
+        "transition-colors"
       )}
       initial={{ opacity: 0, x: -10 }}
       animate={{

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -140,14 +140,15 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
               </motion.div>
             )}
             {/* Close tab button */}
-            <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+            <motion.div whileTap={{ scale: 0.95 }}>
               <Button
                 variant="ghost"
                 size="icon"
                 onClick={handleCloseTab}
-                className="size-5 bg-transparent hover:!bg-white dark:hover:!bg-white/10 text-gray-600 dark:text-gray-400"
+                className="size-5 bg-transparent rounded-sm hover:bg-black/10 dark:hover:bg-white/10"
+                onMouseDown={(event) => event.stopPropagation()}
               >
-                <XIcon className="size-4" />
+                <XIcon className="size-4 text-muted-foreground dark:text-white" />
               </Button>
             </motion.div>
           </div>

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -85,6 +85,7 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
         !isFocused && "hover:bg-black/5 hover:dark:bg-white/10",
         !isFocused && "active:bg-black/10 active:dark:bg-white/20",
         isFocused && "bg-white dark:bg-white/25",
+        isFocused && "active:bg-white active:dark:bg-white/25",
         "text-gray-900 dark:text-gray-200",
         "transition-colors"
       )}

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -6,30 +6,14 @@ import { useEffect, useState } from "react";
 import { motion } from "motion/react";
 import { TabGroup } from "@/components/providers/tabs-provider";
 import { TabData } from "~/types/tabs";
-import { SIDEBAR_HOVER_COLOR } from "@/components/browser-ui/browser-sidebar";
-import { TabGroupMode } from "~/types/tabs";
 
 const MotionSidebarMenuButton = motion(SidebarMenuButton);
 
-export function SidebarTab({
-  tab,
-  isFocused,
-  mode,
-  frontTab
-}: {
-  tab: TabData;
-  isFocused: boolean;
-  mode: TabGroupMode;
-  isFrontTab?: boolean;
-  frontTab?: TabData;
-}) {
+export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolean }) {
   const [cachedFaviconUrl, setCachedFaviconUrl] = useState<string | null>(tab.faviconURL);
-  const [frontFaviconUrl, setFrontFaviconUrl] = useState<string | null>(frontTab?.faviconURL || null);
   const [isError, setIsError] = useState(false);
-  const [isFrontError, setIsFrontError] = useState(false);
   const [isPressed, setIsPressed] = useState(false);
   const noFavicon = !cachedFaviconUrl || isError;
-  const noFrontFavicon = !frontFaviconUrl || isFrontError;
 
   const isMuted = tab.muted;
   const isPlayingAudio = tab.audible;
@@ -46,24 +30,9 @@ export function SidebarTab({
     setIsError(false);
   }, [tab.faviconURL]);
 
-  useEffect(() => {
-    if (frontTab?.faviconURL) {
-      setFrontFaviconUrl(frontTab.faviconURL);
-    } else {
-      setFrontFaviconUrl(null);
-    }
-    // Reset error state when favicon url changes
-    setIsFrontError(false);
-  }, [frontTab?.faviconURL]);
-
   const handleClick = () => {
     if (!tab.id) return;
     flow.tabs.switchToTab(tab.id);
-  };
-
-  const handleFrontTabClick = () => {
-    if (!frontTab?.id) return;
-    flow.tabs.switchToTab(frontTab.id);
   };
 
   const handleCloseTab = (e: React.MouseEvent) => {
@@ -88,46 +57,8 @@ export function SidebarTab({
     // In the future this would call: flow.tabs.toggleMute(tab.id);
   };
 
-  // Apply different styles based on tab group mode
   const getTabStyle = () => {
-    switch (mode) {
-      case "split":
-        return isFocused ? "ring-1 ring-blue-300/40 dark:ring-blue-400/20 bg-white dark:bg-white/5" : "";
-      case "normal":
-        return isFocused ? "bg-white dark:bg-white/10" : "";
-      case "glance":
-        // Only one style for glance mode since we're only showing the back tab
-        return "bg-white dark:bg-white/5";
-      default:
-        return isFocused ? "ring-1 ring-gray-300 dark:ring-white/10" : "";
-    }
-  };
-
-  // For glance mode, we handle the front tab's favicon differently
-  const handleFrontTabFaviconClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (frontTab?.id) {
-      flow.tabs.switchToTab(frontTab.id);
-    }
-  };
-
-  const renderFrontTabIcon = () => {
-    if (!frontTab) return null;
-
-    if (!noFrontFavicon) {
-      return (
-        <img
-          src={frontTab.faviconURL || undefined}
-          alt={frontTab.title}
-          className="size-full rounded-full"
-          onError={() => setIsFrontError(true)}
-          onClick={handleFrontTabClick}
-          title={frontTab.title}
-        />
-      );
-    }
-
-    return <div className="size-full bg-indigo-300/70 dark:bg-indigo-400/30 rounded-full" />;
+    return isFocused ? "bg-white dark:bg-white/10" : "";
   };
 
   return (
@@ -135,9 +66,9 @@ export function SidebarTab({
       key={tab.id}
       onClick={handleClick}
       className={cn(
-        SIDEBAR_HOVER_COLOR,
+        "hover:!bg-gray-200/60 dark:hover:!bg-white/5", // Simplified hover color
         getTabStyle(),
-        "text-gray-900 dark:text-gray-200 hover:!bg-white dark:hover:!bg-white/10"
+        "text-gray-900 dark:text-gray-200"
       )}
       initial={{ opacity: 0, x: -10 }}
       animate={{
@@ -155,123 +86,57 @@ export function SidebarTab({
       layout
     >
       <div className="flex flex-row justify-between w-full h-full">
-        {/* Content layout depends on mode */}
-        {mode === "glance" && frontTab ? (
-          // Glance mode - show back tab with front tab's favicon on right
-          <>
-            {/* Left side (back tab) */}
-            <div className={cn("flex flex-row items-center gap-2 flex-1", open && "min-w-0 overflow-hidden mr-1")}>
-              <motion.div className="w-4 h-4 flex-shrink-0" whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
-                {!noFavicon && (
-                  <img
-                    src={tab.faviconURL || undefined}
-                    alt={tab.title}
-                    className="size-full"
-                    onError={() => setIsError(true)}
-                    onClick={handleClick}
-                    onMouseDown={handleMouseDown}
-                  />
-                )}
-                {noFavicon && <div className="size-full bg-gray-300 dark:bg-gray-500/30 rounded-sm" />}
-              </motion.div>
-              <span className="truncate min-w-0 flex-1 font-medium">{tab.title}</span>
-            </div>
-            {/* Right side (front tab favicon) */}
-            <div className={cn("flex flex-row items-center gap-2", open && "flex-shrink-0")}>
-              {/* Audio indicator */}
-              {(isPlayingAudio || isMuted) && (
-                <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={handleToggleMute}
-                    className="size-5 bg-transparent hover:!bg-white dark:hover:!bg-white/10 text-gray-600 dark:text-gray-400"
-                    title={isMuted ? "Unmute tab" : "Mute tab"}
-                  >
-                    {isMuted ? <VolumeX className="size-4" /> : <Volume2 className="size-4" />}
-                  </Button>
-                </motion.div>
+        {/* Normal layout */}
+        <>
+          {/* Left side */}
+          <div className={cn("flex flex-row items-center gap-2 flex-1", open && "min-w-0 overflow-hidden mr-1")}>
+            <motion.div className="w-4 h-4 flex-shrink-0" whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
+              {!noFavicon && (
+                <img
+                  src={tab.faviconURL || undefined}
+                  alt={tab.title}
+                  className="size-full"
+                  onError={() => setIsError(true)}
+                  onClick={handleClick}
+                  onMouseDown={handleMouseDown}
+                />
               )}
-              {/* Close tab button */}
+              {noFavicon && <div className="size-full bg-gray-300 dark:bg-gray-500/30 rounded-sm" />}
+            </motion.div>
+            <span className="truncate min-w-0 flex-1 font-medium">{tab.title}</span>
+          </div>
+          {/* Right side */}
+          <div className={cn("flex flex-row items-center gap-2 rounded-md aspect-square", open && "flex-shrink-0")}>
+            {/* Audio indicator */}
+            {(isPlayingAudio || isMuted) && (
               <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={handleCloseTab}
+                  onClick={handleToggleMute}
                   className="size-5 bg-transparent hover:!bg-white dark:hover:!bg-white/10 text-gray-600 dark:text-gray-400"
+                  title={isMuted ? "Unmute tab" : "Mute tab"}
                 >
-                  <XIcon className="size-4" />
+                  {isMuted ? <VolumeX className="size-4" /> : <Volume2 className="size-4" />}
                 </Button>
               </motion.div>
-              {/* Front tab favicon */}
-              <motion.div
-                className="w-5 h-5 flex-shrink-0 ring-1 ring-gray-300 dark:ring-white/10 rounded-full bg-white dark:bg-white/5 p-0.5"
-                whileHover={{ scale: 1.1 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={handleFrontTabFaviconClick}
+            )}
+            {/* Close tab button */}
+            <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleCloseTab}
+                className="size-5 bg-transparent hover:!bg-white dark:hover:!bg-white/10 text-gray-600 dark:text-gray-400"
               >
-                {renderFrontTabIcon()}
-              </motion.div>
-            </div>
-          </>
-        ) : (
-          // Normal and Split modes - standard layout
-          <>
-            {/* Left side */}
-            <div className={cn("flex flex-row items-center gap-2 flex-1", open && "min-w-0 overflow-hidden mr-1")}>
-              <motion.div className="w-4 h-4 flex-shrink-0" whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
-                {!noFavicon && (
-                  <img
-                    src={tab.faviconURL || undefined}
-                    alt={tab.title}
-                    className="size-full"
-                    onError={() => setIsError(true)}
-                    onClick={handleClick}
-                    onMouseDown={handleMouseDown}
-                  />
-                )}
-                {noFavicon && <div className="size-full bg-gray-300 dark:bg-gray-500/30 rounded-sm" />}
-              </motion.div>
-              <span className="truncate min-w-0 flex-1 font-medium">{tab.title}</span>
-            </div>
-            {/* Right side */}
-            <div className={cn("flex flex-row items-center gap-2 rounded-md aspect-square", open && "flex-shrink-0")}>
-              {/* Audio indicator */}
-              {(isPlayingAudio || isMuted) && (
-                <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={handleToggleMute}
-                    className="size-5 bg-transparent hover:!bg-white dark:hover:!bg-white/10 text-gray-600 dark:text-gray-400"
-                    title={isMuted ? "Unmute tab" : "Mute tab"}
-                  >
-                    {isMuted ? <VolumeX className="size-4" /> : <Volume2 className="size-4" />}
-                  </Button>
-                </motion.div>
-              )}
-              {/* Close tab button */}
-              <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleCloseTab}
-                  className="size-5 bg-transparent hover:!bg-white dark:hover:!bg-white/10 text-gray-600 dark:text-gray-400"
-                >
-                  <XIcon className="size-4" />
-                </Button>
-              </motion.div>
-            </div>
-          </>
-        )}
+                <XIcon className="size-4" />
+              </Button>
+            </motion.div>
+          </div>
+        </>
       </div>
     </MotionSidebarMenuButton>
   );
-}
-
-// Extended TabGroup type with glanceFrontTabId
-interface GlanceTabGroup extends TabGroup {
-  glanceFrontTabId?: number;
 }
 
 export function SidebarTabGroups({
@@ -279,22 +144,10 @@ export function SidebarTabGroups({
   isFocused
 }: {
   tabGroup: TabGroup;
-  isActive: boolean;
+  isActive: boolean; // isActive might still be needed depending on parent component logic
   isFocused: boolean;
 }) {
-  const { tabs, focusedTab, mode } = tabGroup;
-  const glanceFrontTabId = mode === "glance" ? (tabGroup as GlanceTabGroup).glanceFrontTabId : undefined;
-
-  // For glance mode, we need to separate front and back tabs
-  let displayTabs = tabs;
-  let frontTab: TabData | undefined;
-
-  if (mode === "glance" && glanceFrontTabId) {
-    // Find the front tab
-    frontTab = tabs.find((tab) => tab.id === glanceFrontTabId);
-    // Only display back tabs in glance mode
-    displayTabs = tabs.filter((tab) => tab.id !== glanceFrontTabId);
-  }
+  const { tabs, focusedTab } = tabGroup;
 
   return (
     <motion.div
@@ -302,16 +155,10 @@ export function SidebarTabGroups({
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       layout
-      className={cn("space-y-0.5", mode === "split" && "p-1 rounded-md bg-white/90 dark:bg-white/5")}
+      className="space-y-0.5" // Removed split mode specific padding and background
     >
-      {displayTabs.map((tab) => (
-        <SidebarTab
-          key={tab.id}
-          tab={tab}
-          isFocused={isFocused && focusedTab?.id === tab.id}
-          mode={mode || "normal"}
-          frontTab={mode === "glance" ? frontTab : undefined}
-        />
+      {tabs.map((tab) => (
+        <SidebarTab key={tab.id} tab={tab} isFocused={isFocused && focusedTab?.id === tab.id} />
       ))}
     </motion.div>
   );

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -42,6 +42,10 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
+    // Left mouse button
+    if (e.button === 0) {
+      handleClick();
+    }
     // Middle mouse button
     if (e.button === 1) {
       handleCloseTab(e);
@@ -57,23 +61,30 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
     // In the future this would call: flow.tabs.toggleMute(tab.id);
   };
 
-  const getTabStyle = () => {
-    return isFocused ? "bg-white dark:bg-white/10" : "";
-  };
-
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
     flow.tabs.showContextMenu(tab.id);
   };
 
+  useEffect(() => {
+    const handleMouseUp = () => {
+      setIsPressed(false);
+    };
+    window.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
   return (
     <MotionSidebarMenuButton
       key={tab.id}
-      onClick={handleClick}
       onContextMenu={handleContextMenu}
       className={cn(
-        "hover:!bg-gray-200/60 dark:hover:!bg-white/5", // Simplified hover color
-        getTabStyle(),
+        "bg-transparent active:bg-transparent",
+        !isFocused && "hover:bg-black/5 hover:dark:bg-white/10",
+        !isFocused && "active:bg-black/10 active:dark:bg-white/20",
+        isFocused && "bg-white dark:bg-white/25",
         "text-gray-900 dark:text-gray-200",
         "transition-colors"
       )}
@@ -81,7 +92,7 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
       animate={{
         opacity: 1,
         x: 0,
-        scale: isPressed ? 0.975 : 1
+        scale: isPressed ? 0.985 : 1
       }}
       exit={{ opacity: 0, x: -10 }}
       onMouseDown={handleMouseDown}

--- a/src/shared/flow/interfaces/browser/tabs.ts
+++ b/src/shared/flow/interfaces/browser/tabs.ts
@@ -36,6 +36,12 @@ export interface FlowTabsAPI {
   closeTab: (tabId: number) => Promise<boolean>;
 
   /**
+   * Show the context menu for a tab
+   * @param tabId The id of the tab to show the context menu for
+   */
+  showContextMenu: (tabId: number) => void;
+
+  /**
    * Disable Picture in Picture mode for a tab
    */
   disablePictureInPicture: () => Promise<boolean>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a context menu for browser tabs, accessible by right-clicking a tab. Menu options include copying the tab URL, toggling sleep/wake state, and closing the tab.

- **Refactor**
  - Simplified the sidebar tab interface by removing support for multiple tab group modes and streamlining event handling and styling for a more consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->