### PR TITLE
Fix browser flick on extension view opening

### DIFF
--- a/src/main/browser/components/portal-component-windows.ts
+++ b/src/main/browser/components/portal-component-windows.ts
@@ -83,6 +83,8 @@ export function initializePortalComponentWindows(tabbedWindow: TabbedBrowserWind
     if (componentView) {
       debugPrint("PORTAL_COMPONENTS", "Set Visibility of Portal Window:", componentId, visible);
       if (visible) {
+        // A hack to fix browser flick on extension view opening
+        // TODO: Find a better solution
         setTimeout(() => {
           componentView.setVisible(true);
         }, 50);

--- a/src/main/browser/components/portal-component-windows.ts
+++ b/src/main/browser/components/portal-component-windows.ts
@@ -33,6 +33,7 @@ export function initializePortalComponentWindows(tabbedWindow: TabbedBrowserWind
         });
         const webContents = componentView.webContents;
 
+        componentView.setVisible(false);
         tabbedWindow.viewManager.addOrUpdateView(componentView, DEFAULT_Z_INDEX);
 
         debugPrint("PORTAL_COMPONENTS", "Created Portal Window:", componentId);
@@ -81,7 +82,9 @@ export function initializePortalComponentWindows(tabbedWindow: TabbedBrowserWind
     const componentView = componentViews[componentId];
     if (componentView) {
       debugPrint("PORTAL_COMPONENTS", "Set Visibility of Portal Window:", componentId, visible);
-      componentView.setVisible(visible);
+      setTimeout(() => {
+        componentView.setVisible(true);
+      }, 50);
     }
   };
   ipcMain.on("interface:set-component-window-visible", setComponentWindowVisible);

--- a/src/main/browser/components/portal-component-windows.ts
+++ b/src/main/browser/components/portal-component-windows.ts
@@ -82,9 +82,13 @@ export function initializePortalComponentWindows(tabbedWindow: TabbedBrowserWind
     const componentView = componentViews[componentId];
     if (componentView) {
       debugPrint("PORTAL_COMPONENTS", "Set Visibility of Portal Window:", componentId, visible);
-      setTimeout(() => {
-        componentView.setVisible(true);
-      }, 50);
+      if (visible) {
+        setTimeout(() => {
+          componentView.setVisible(true);
+        }, 50);
+      } else {
+        componentView.setVisible(false);
+      }
     }
   };
   ipcMain.on("interface:set-component-window-visible", setComponentWindowVisible);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Newly created portal component windows now start hidden and become visible after a brief delay, ensuring a smoother and more controlled display experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->