### PR TITLE
Tab auto sleep feature

### DIFF
--- a/src/main/browser/tabs/tab-manager.ts
+++ b/src/main/browser/tabs/tab-manager.ts
@@ -6,7 +6,7 @@ import { SplitTabGroup } from "@/browser/tabs/tab-groups/split";
 import { windowTabsChanged } from "@/ipc/browser/tabs";
 import { setWindowSpace } from "@/ipc/session/spaces";
 import { TypedEventEmitter } from "@/modules/typed-event-emitter";
-import { shouldArchiveTab } from "@/saving/tabs";
+import { shouldArchiveTab, shouldSleepTab } from "@/saving/tabs";
 import { getLastUsedSpace, getLastUsedSpaceFromProfile } from "@/sessions/spaces";
 import { WebContents } from "electron";
 import { TabGroupMode } from "~/types/tabs";
@@ -82,6 +82,9 @@ export class TabManager extends TypedEventEmitter<TabManagerEvents> {
       for (const tab of this.tabs.values()) {
         if (!tab.visible && shouldArchiveTab(tab.lastActiveAt)) {
           tab.destroy();
+        }
+        if (!tab.visible && !tab.asleep && shouldSleepTab(tab.lastActiveAt)) {
+          tab.putToSleep();
         }
       }
     }, ARCHIVE_CHECK_INTERVAL_MS);

--- a/src/main/modules/basic-settings.ts
+++ b/src/main/modules/basic-settings.ts
@@ -15,6 +15,23 @@ export const ArchiveTabValueMap = {
   never: Infinity
 };
 
+/**
+ * Maps sleep tab duration settings to their equivalent values in seconds.
+ * 'never' is mapped to Infinity.
+ */
+export const SleepTabValueMap = {
+  "5m": 5 * 60,
+  "10m": 10 * 60,
+  "30m": 30 * 60,
+  "1h": 60 * 60,
+  "2h": 2 * 60 * 60,
+  "4h": 4 * 60 * 60,
+  "8h": 8 * 60 * 60,
+  "12h": 12 * 60 * 60,
+  "24h": 24 * 60 * 60,
+  never: Infinity
+};
+
 export const BasicSettings: BasicSetting[] = [
   // [GENERAL] Auto Update
   {
@@ -140,6 +157,57 @@ export const BasicSettings: BasicSetting[] = [
     ]
   },
 
+  // Sleep Tab After
+  {
+    id: "sleepTabAfter",
+    name: "Sleep Tab After",
+    showName: false,
+    type: "enum",
+    defaultValue: "never",
+    options: [
+      {
+        id: "5m",
+        name: "5 Minutes"
+      },
+      {
+        id: "10m",
+        name: "10 Minutes"
+      },
+      {
+        id: "30m",
+        name: "30 Minutes"
+      },
+      {
+        id: "1h",
+        name: "1 Hour"
+      },
+      {
+        id: "2h",
+        name: "2 Hours"
+      },
+      {
+        id: "4h",
+        name: "4 Hours"
+      },
+      {
+        id: "8h",
+        name: "8 Hours"
+      },
+      {
+        id: "12h",
+        name: "12 Hours"
+      },
+      {
+        id: "24h",
+        name: "24 Hours"
+      },
+      {
+        id: "never",
+        name: "Never"
+      }
+    ]
+  },
+
   // [ADVANCED] Enable mv2 extensions
   {
     id: "enableMv2Extensions",
@@ -184,6 +252,13 @@ export const BasicSettingCards: BasicSettingCard[] = [
     title: "Archive Tab After",
     subtitle: "Choose how long tabs should be archived",
     settings: ["archiveTabAfter"]
+  },
+
+  // Sleep Tab After Card
+  {
+    title: "Sleep Tab After",
+    subtitle: "Choose how long tabs should be put to sleep",
+    settings: ["sleepTabAfter"]
   },
 
   // Onboarding Card (Internal)

--- a/src/main/modules/basic-settings.ts
+++ b/src/main/modules/basic-settings.ts
@@ -247,18 +247,11 @@ export const BasicSettingCards: BasicSettingCard[] = [
     settings: ["sidebarSide", "sidebarCollapseMode"]
   },
 
-  // Archive Tab After Card
+  // Performance Settings Card
   {
-    title: "Archive Tab After",
-    subtitle: "Choose how long tabs should be archived",
-    settings: ["archiveTabAfter"]
-  },
-
-  // Sleep Tab After Card
-  {
-    title: "Sleep Tab After",
-    subtitle: "Choose how long tabs should be put to sleep",
-    settings: ["sleepTabAfter"]
+    title: "Performance Settings",
+    subtitle: "Settings to improve performance",
+    settings: ["archiveTabAfter", "sleepTabAfter"]
   },
 
   // Onboarding Card (Internal)

--- a/src/main/saving/tabs.ts
+++ b/src/main/saving/tabs.ts
@@ -2,7 +2,7 @@ import { Browser } from "@/browser/browser";
 import { SLEEP_MODE_URL, Tab } from "@/browser/tabs/tab";
 import { browser } from "@/index";
 import { getTabData } from "@/ipc/browser/tabs";
-import { ArchiveTabValueMap } from "@/modules/basic-settings";
+import { ArchiveTabValueMap, SleepTabValueMap } from "@/modules/basic-settings";
 import { getDatastore } from "@/saving/datastore";
 import { getSettingValueById } from "@/saving/settings";
 import { app } from "electron";
@@ -59,6 +59,17 @@ export function shouldArchiveTab(lastActiveAt: number) {
   const now = Math.floor(Date.now() / 1000);
   const diff = now - lastActiveAt;
   return diff > archiveTabAfterSeconds;
+}
+
+export function shouldSleepTab(lastActiveAt: number) {
+  const sleepTabAfter = getSettingValueById("sleepTabAfter");
+  const sleepTabAfterSeconds = SleepTabValueMap[sleepTabAfter as keyof typeof SleepTabValueMap];
+
+  if (typeof sleepTabAfterSeconds !== "number") return false;
+
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - lastActiveAt;
+  return diff > sleepTabAfterSeconds;
 }
 
 export async function loadTabsFromStorage() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Sleep Tab After" setting, allowing users to specify when inactive tabs should be put to sleep (options range from 5 minutes to 24 hours, or never).
  - Tabs that are inactive for the configured duration will now automatically enter sleep mode, helping conserve system resources.

- **Settings**
  - Updated the performance settings card to include both tab archiving and sleeping options for improved resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->