### PR TITLE
Reorder & Move Tabs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,8 @@
         "zod": "^3.24.4",
       },
       "devDependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.6.1",
+        "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^3.2.0",
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
         "@electron-toolkit/eslint-config-ts": "^3.1.0",
         "@electron-toolkit/tsconfig": "^1.0.1",
@@ -92,6 +94,22 @@
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
+    "@atlaskit/atlassian-context": ["@atlaskit/atlassian-context@0.2.0", "", { "dependencies": { "@babel/runtime": "^7.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-msLRSp0qck6eflkShplgyIoOogNKxKRc6QIWGQlSvKGxHQNEbLEkRGcDzdh8PuBxSs1gda7OqYrdtQYQiPbpTQ=="],
+
+    "@atlaskit/ds-lib": ["@atlaskit/ds-lib@4.0.0", "", { "dependencies": { "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "bind-event-listener": "^3.0.0", "react-uid": "^2.2.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-nM0wAo8bm7FyAYuId6Ba2MFnLSVzlsZpyfRxPJ7dMFqEhJ4R53/CoT8v18mvi2Hu1Y4+d1t97lOyybHfgFyb+A=="],
+
+    "@atlaskit/feature-gate-js-client": ["@atlaskit/feature-gate-js-client@5.3.1", "", { "dependencies": { "@atlaskit/atlassian-context": "^0.2.0", "@babel/runtime": "^7.0.0", "@statsig/client-core": "^3.16.0", "@statsig/js-client": "^3.16.0", "eventemitter2": "^4.1.0" } }, "sha512-2ZsxZ3r2+J22fT341JzR/vad1N95OK5hHybJC5iVQ961+x0q6pjRikaqOtRjGfcH6tOmV4br4wb14DeHH1YcbQ=="],
+
+    "@atlaskit/platform-feature-flags": ["@atlaskit/platform-feature-flags@1.1.1", "", { "dependencies": { "@atlaskit/feature-gate-js-client": "^5.0.0", "@babel/runtime": "^7.0.0" } }, "sha512-YKuy3RsqCEoNALiMHVma0GGHkzZMSIBsEgZlV/2TPw65QRzOWJvKA3ZIKucmXzr3m7AUqg1XHwXvVlUuNZhUgg=="],
+
+    "@atlaskit/pragmatic-drag-and-drop": ["@atlaskit/pragmatic-drag-and-drop@1.6.1", "", { "dependencies": { "@babel/runtime": "^7.0.0", "bind-event-listener": "^3.0.0", "raf-schd": "^4.0.3" } }, "sha512-RC0E/uicBBIoCxHOLcrFf0DP9N4h6AfluSdz8yC4ttYu1Q3UPbnpBEBQGdOxdl3vcNsB06zw378Nj6eNnxbzFg=="],
+
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": ["@atlaskit/pragmatic-drag-and-drop-hitbox@1.1.0", "", { "dependencies": { "@atlaskit/pragmatic-drag-and-drop": "^1.6.0", "@babel/runtime": "^7.0.0" } }, "sha512-JWt6eVp6Br2FPHRM8s0dUIHQk/jFInGP1f3ti5CdtM1Ji5/pt8Akm44wDC063Gv2i5RGseixtbW0z/t6RYtbdg=="],
+
+    "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": ["@atlaskit/pragmatic-drag-and-drop-react-drop-indicator@3.2.0", "", { "dependencies": { "@atlaskit/pragmatic-drag-and-drop": "^1.6.0", "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0", "@atlaskit/tokens": "^4.8.0", "@babel/runtime": "^7.0.0", "@compiled/react": "^0.18.3" }, "peerDependencies": { "react": "^18.2.0 || ^19.0.0" } }, "sha512-hyWgXl7yztQw1am7xx5N3Az7dktvF4hL3O6PWcRSb3cJ43KH2R+mIshYos7b2d7ST+z2+yPpIXlVcpiRHjLBgw=="],
+
+    "@atlaskit/tokens": ["@atlaskit/tokens@4.9.0", "", { "dependencies": { "@atlaskit/ds-lib": "^4.0.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-Pabyg7ZZjAUzCaPWLwJWzkniN7J6rAKGjfkJH3gNy1KGoyHp31iRwRJ2wZIBY1rCj5iu9GTFlSfabn4HHQZdEw=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.27.2", "", {}, "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ=="],
@@ -133,6 +151,8 @@
     "@babel/types": ["@babel/types@7.27.1", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q=="],
 
     "@canvas/image-data": ["@canvas/image-data@1.0.0", "", {}, "sha512-BxOqI5LgsIQP1odU5KMwV9yoijleOPzHL18/YvNqF9KFSGF2K/DLlYAbDQsWqd/1nbaFuSkYD/191dpMtNh4vw=="],
+
+    "@compiled/react": ["@compiled/react@0.18.4", "", { "dependencies": { "csstype": "^3.1.3" }, "peerDependencies": { "react": ">= 16.12.0" } }, "sha512-tO0cAZTOMky8IcBscs6VQsMRUos8nXixIsQWPY8XWbF5JYYkIxuJ0ojpkjdUBkXBdgdjBjp6kczoub8BLPjHZg=="],
 
     "@develar/schema-utils": ["@develar/schema-utils@2.6.5", "", { "dependencies": { "ajv": "^6.12.0", "ajv-keywords": "^3.4.1" } }, "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig=="],
 
@@ -518,6 +538,10 @@
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
+    "@statsig/client-core": ["@statsig/client-core@3.17.1", "", {}, "sha512-e5L9Uea8FyjTrEGJOq0Hvejc+4WgTAr0vTogcEiUtnQ6UAyEaPWq+B+UmMx0S7SbZVjegOkEZTytjvqurTq2fQ=="],
+
+    "@statsig/js-client": ["@statsig/js-client@3.17.1", "", { "dependencies": { "@statsig/client-core": "3.17.1" } }, "sha512-qMi/5GQWT0f6juzoJWzdZHPJ7XfxyWfZtnUTTKItYHRD0FCkLJP0GLh0CIentrfwV/l5FJKTtMlA74uNTYHbEA=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.17", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
@@ -703,6 +727,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
+
+    "bind-event-listener": ["bind-event-listener@3.0.0", "", {}, "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
@@ -987,6 +1013,8 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter2": ["eventemitter2@4.1.2", "", {}, "sha512-erx0niBaTi8B7ywjGAcg8ilGNRl/xs/o4MO2ZMpRlpZ62mYzjGTBlOpxxRIrPQqBs9mbXkEux6aR+Sc5vQ/wUw=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -1534,6 +1562,8 @@
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
+    "raf-schd": ["raf-schd@4.0.3", "", {}, "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="],
+
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.0", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.6.3", "unpipe": "1.0.0" } }, "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g=="],
@@ -1553,6 +1583,8 @@
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-uid": ["react-uid@2.4.0", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-+MVs/25NrcZuGrmlVRWPOSsbS8y72GJOBsR7d68j3/wqOrRBF52U29XAw4+XSelw0Vm6s5VmGH5mCbTCPGVCVg=="],
 
     "react-universal-interface": ["react-universal-interface@0.6.2", "", { "peerDependencies": { "react": "*", "tslib": "*" } }, "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="],
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "zod": "^3.24.4"
   },
   "devDependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^1.6.1",
+    "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^3.2.0",
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
     "@electron-toolkit/eslint-config-ts": "^3.1.0",
     "@electron-toolkit/tsconfig": "^1.0.1",

--- a/src/main/browser/tabs/tab-groups/index.ts
+++ b/src/main/browser/tabs/tab-groups/index.ts
@@ -210,6 +210,11 @@ export class BaseTabGroup extends TypedEventEmitter<TabGroupEvents> {
       .filter((tab) => tab !== null);
   }
 
+  public get order(): number {
+    this.errorIfDestroyed();
+    return this.tabs[0].order;
+  }
+
   public destroy() {
     this.errorIfDestroyed();
 

--- a/src/main/browser/tabs/tab-groups/index.ts
+++ b/src/main/browser/tabs/tab-groups/index.ts
@@ -210,9 +210,9 @@ export class BaseTabGroup extends TypedEventEmitter<TabGroupEvents> {
       .filter((tab) => tab !== null);
   }
 
-  public get order(): number {
+  public get position(): number {
     this.errorIfDestroyed();
-    return this.tabs[0].order;
+    return this.tabs[0].position;
   }
 
   public destroy() {

--- a/src/main/browser/tabs/tab-manager.ts
+++ b/src/main/browser/tabs/tab-manager.ts
@@ -650,6 +650,19 @@ export class TabManager extends TypedEventEmitter<TabManagerEvents> {
   }
 
   /**
+   * Get the smallest position of all tabs
+   */
+  public getSmallestPosition(): number {
+    let smallestPosition = 999;
+    for (const tab of this.tabs.values()) {
+      if (tab.position < smallestPosition) {
+        smallestPosition = tab.position;
+      }
+    }
+    return smallestPosition;
+  }
+
+  /**
    * Internal method to cleanup destroyed tab group state
    */
   private internalDestroyTabGroup(tabGroup: TabGroup) {

--- a/src/main/browser/tabs/tab.ts
+++ b/src/main/browser/tabs/tab.ts
@@ -72,6 +72,7 @@ export interface TabCreationOptions {
 
   // Options
   asleep?: boolean;
+  position?: number;
 
   // Old States to be restored
   title?: string;
@@ -131,7 +132,7 @@ export class Tab extends TypedEventEmitter<TabEvents> {
   public asleep: boolean = false;
   public createdAt: number;
   public lastActiveAt: number;
-  public position: number = 0;
+  public position: number;
 
   // Content properties (From WebContents)
   public title: string = "New Tab";
@@ -192,6 +193,7 @@ export class Tab extends TypedEventEmitter<TabEvents> {
 
       // Options
       asleep = false,
+      position,
 
       // Old States to be restored
       title,
@@ -205,6 +207,15 @@ export class Tab extends TypedEventEmitter<TabEvents> {
       this.uniqueId = generateID();
     } else {
       this.uniqueId = uniqueId;
+    }
+
+    // Set position
+    if (position) {
+      this.position = position;
+    } else {
+      // Get the smallest position
+      const smallestPosition = this.tabManager.getSmallestPosition();
+      this.position = smallestPosition - 1;
     }
 
     // Create WebContentsView

--- a/src/main/browser/tabs/tab.ts
+++ b/src/main/browser/tabs/tab.ts
@@ -34,7 +34,8 @@ type TabStateProperty =
   | "fullScreen"
   | "isPictureInPicture"
   | "asleep"
-  | "lastActiveAt";
+  | "lastActiveAt"
+  | "order";
 type TabContentProperty = "title" | "url" | "isLoading" | "audible" | "muted" | "navHistory" | "navHistoryIndex";
 
 type TabPublicProperty = TabStateProperty | TabContentProperty;
@@ -130,6 +131,7 @@ export class Tab extends TypedEventEmitter<TabEvents> {
   public asleep: boolean = false;
   public createdAt: number;
   public lastActiveAt: number;
+  public order: number = 0;
 
   // Content properties (From WebContents)
   public title: string = "New Tab";

--- a/src/main/browser/tabs/tab.ts
+++ b/src/main/browser/tabs/tab.ts
@@ -210,7 +210,7 @@ export class Tab extends TypedEventEmitter<TabEvents> {
     }
 
     // Set position
-    if (position) {
+    if (position !== undefined) {
       this.position = position;
     } else {
       // Get the smallest position

--- a/src/main/browser/tabs/tab.ts
+++ b/src/main/browser/tabs/tab.ts
@@ -35,7 +35,7 @@ type TabStateProperty =
   | "isPictureInPicture"
   | "asleep"
   | "lastActiveAt"
-  | "order";
+  | "position";
 type TabContentProperty = "title" | "url" | "isLoading" | "audible" | "muted" | "navHistory" | "navHistoryIndex";
 
 type TabPublicProperty = TabStateProperty | TabContentProperty;
@@ -131,7 +131,7 @@ export class Tab extends TypedEventEmitter<TabEvents> {
   public asleep: boolean = false;
   public createdAt: number;
   public lastActiveAt: number;
-  public order: number = 0;
+  public position: number = 0;
 
   // Content properties (From WebContents)
   public title: string = "New Tab";

--- a/src/main/ipc/browser/tabs.ts
+++ b/src/main/ipc/browser/tabs.ts
@@ -12,7 +12,7 @@ export function getTabData(tab: Tab): TabData {
     uniqueId: tab.uniqueId,
     createdAt: tab.createdAt,
     lastActiveAt: tab.lastActiveAt,
-    order: tab.order,
+    position: tab.position,
 
     profileId: tab.profileId,
     spaceId: tab.spaceId,
@@ -41,7 +41,7 @@ export function getTabGroupData(tabGroup: TabGroup): TabGroupData {
     spaceId: tabGroup.spaceId,
     tabIds: tabGroup.tabs.map((tab) => tab.id),
     glanceFrontTabId: tabGroup.mode === "glance" ? tabGroup.frontTabId : undefined,
-    order: tabGroup.order
+    position: tabGroup.position
   };
 }
 

--- a/src/main/ipc/browser/tabs.ts
+++ b/src/main/ipc/browser/tabs.ts
@@ -230,6 +230,30 @@ ipcMain.handle("tabs:set-tab-muted", async (_event, tabId: number, muted: boolea
 
   // No event for mute state change, so we need to update the tab state manually
   tab.updateTabState();
+  return true;
+});
+
+ipcMain.handle("tabs:move-tab", async (event, tabId: number, newPosition: number) => {
+  const webContents = event.sender;
+  const window = browser?.getWindowFromWebContents(webContents);
+  if (!window) return false;
+
+  const tabManager = browser?.tabs;
+  if (!tabManager) return false;
+
+  const tab = tabManager.getTabById(tabId);
+  if (!tab) return false;
+
+  let targetTabs: Tab[] = [tab];
+
+  const tabGroup = tabManager.getTabGroupByTabId(tab.id);
+  if (tabGroup) {
+    targetTabs = tabGroup.tabs;
+  }
+
+  for (const targetTab of targetTabs) {
+    targetTab.updateStateProperty("position", newPosition);
+  }
 
   return true;
 });

--- a/src/main/ipc/browser/tabs.ts
+++ b/src/main/ipc/browser/tabs.ts
@@ -252,7 +252,6 @@ ipcMain.handle("tabs:move-tab", async (event, tabId: number, newPosition: number
   }
 
   for (const targetTab of targetTabs) {
-    console.log("moving tab", targetTab.id, newPosition);
     targetTab.updateStateProperty("position", newPosition);
   }
 
@@ -276,7 +275,7 @@ ipcMain.handle("tabs:move-tab-to-window-space", async (event, tabId: number, spa
   tab.setSpace(spaceId);
   tab.setWindow(window);
 
-  if (newPosition) {
+  if (newPosition !== undefined) {
     tab.updateStateProperty("position", newPosition);
   }
 

--- a/src/main/ipc/browser/tabs.ts
+++ b/src/main/ipc/browser/tabs.ts
@@ -258,6 +258,31 @@ ipcMain.handle("tabs:move-tab", async (event, tabId: number, newPosition: number
   return true;
 });
 
+ipcMain.handle("tabs:move-tab-to-window-space", async (event, tabId: number, spaceId: string, newPosition?: number) => {
+  const webContents = event.sender;
+  const window = browser?.getWindowFromWebContents(webContents);
+  if (!window) return false;
+
+  const tabManager = browser?.tabs;
+  if (!tabManager) return false;
+
+  const tab = tabManager.getTabById(tabId);
+  if (!tab) return false;
+
+  const space = await getSpace(spaceId);
+  if (!space) return false;
+
+  tab.setSpace(spaceId);
+  tab.setWindow(window);
+
+  if (newPosition) {
+    tab.updateStateProperty("position", newPosition);
+  }
+
+  tabManager.setActiveTab(tab);
+  return true;
+});
+
 ipcMain.on("tabs:show-context-menu", (event, tabId: number) => {
   const webContents = event.sender;
   const tabbedWindow = browser?.getWindowFromWebContents(webContents);

--- a/src/main/ipc/browser/tabs.ts
+++ b/src/main/ipc/browser/tabs.ts
@@ -252,6 +252,7 @@ ipcMain.handle("tabs:move-tab", async (event, tabId: number, newPosition: number
   }
 
   for (const targetTab of targetTabs) {
+    console.log("moving tab", targetTab.id, newPosition);
     targetTab.updateStateProperty("position", newPosition);
   }
 

--- a/src/main/ipc/browser/tabs.ts
+++ b/src/main/ipc/browser/tabs.ts
@@ -12,6 +12,7 @@ export function getTabData(tab: Tab): TabData {
     uniqueId: tab.uniqueId,
     createdAt: tab.createdAt,
     lastActiveAt: tab.lastActiveAt,
+    order: tab.order,
 
     profileId: tab.profileId,
     spaceId: tab.spaceId,
@@ -39,7 +40,8 @@ export function getTabGroupData(tabGroup: TabGroup): TabGroupData {
     profileId: tabGroup.profileId,
     spaceId: tabGroup.spaceId,
     tabIds: tabGroup.tabs.map((tab) => tab.id),
-    glanceFrontTabId: tabGroup.mode === "glance" ? tabGroup.frontTabId : undefined
+    glanceFrontTabId: tabGroup.mode === "glance" ? tabGroup.frontTabId : undefined,
+    order: tabGroup.order
   };
 }
 

--- a/src/main/saving/tabs.ts
+++ b/src/main/saving/tabs.ts
@@ -18,18 +18,45 @@ export async function persistTabToStorage(tab: Tab) {
   if (window.type !== "normal") return;
 
   // Prevent saving tabs stuck in sleep mode
-  if (tab.url === SLEEP_MODE_URL) return;
-  if (tab.asleep) return;
-  if (tab.navHistory.length === 0) return;
+  // if (tab.url === SLEEP_MODE_URL) return;
+  // if (tab.asleep) return;
+  // if (tab.navHistory.length === 0) return;
 
   const uniqueId = tab.uniqueId;
   const tabData = getTabData(tab);
 
   // Do NOT save sleep tabs
-  if (tab.navHistory.find((entry) => entry.url === SLEEP_MODE_URL)) return;
+  const asleep = tab.asleep;
+  const saveURL = !asleep && tab.url !== SLEEP_MODE_URL;
+  const saveNavHistory = !asleep && !tab.navHistory.find((entry) => entry.url === SLEEP_MODE_URL);
+
+  const recoverFromOldData = !saveURL || !saveNavHistory;
+
+  // Transform the tab data
+  const transformedTabData = {
+    ...tabData
+  };
+
+  if (recoverFromOldData) {
+    const oldTabData = await TabsDataStore.get<TabData>(uniqueId);
+    if (!oldTabData) return;
+
+    const oldTabDataUrl = oldTabData?.url;
+    if (!saveURL) {
+      if (!oldTabDataUrl) return;
+      transformedTabData.url = oldTabDataUrl;
+    }
+
+    const oldTabDataNavHistory = oldTabData?.navHistory;
+    if (!saveNavHistory) {
+      if (!oldTabDataNavHistory) return;
+      transformedTabData.navHistory = oldTabDataNavHistory;
+    }
+  }
 
   // Save the tab data
-  return await TabsDataStore.set(uniqueId, tabData)
+  console.log("saving tab", tabData.id, tabData.position);
+  return await TabsDataStore.set(uniqueId, transformedTabData)
     .then(() => true)
     .catch(() => false);
 }
@@ -112,6 +139,7 @@ async function createTabsFromTabDatas(browser: Browser, tabDatas: TabData[]) {
     for (const tabData of tabs) {
       browser.tabs.createTab(window.id, tabData.profileId, tabData.spaceId, undefined, {
         asleep: true,
+        position: tabData.position,
         navHistory: tabData.navHistory,
         navHistoryIndex: tabData.navHistoryIndex,
         uniqueId: tabData.uniqueId,

--- a/src/main/saving/tabs.ts
+++ b/src/main/saving/tabs.ts
@@ -55,7 +55,6 @@ export async function persistTabToStorage(tab: Tab) {
   }
 
   // Save the tab data
-  console.log("saving tab", tabData.id, tabData.position);
   return await TabsDataStore.set(uniqueId, transformedTabData)
     .then(() => true)
     .catch(() => false);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -241,6 +241,10 @@ const tabsAPI: FlowTabsAPI = {
     return ipcRenderer.invoke("tabs:move-tab", tabId, newPosition);
   },
 
+  moveTabToWindowSpace: async (tabId: number, spaceId: string, newPosition?: number) => {
+    return ipcRenderer.invoke("tabs:move-tab-to-window-space", tabId, spaceId, newPosition);
+  },
+
   // Special Exception: This is allowed for all internal protocols.
   newTab: async (url?: string, isForeground?: boolean, spaceId?: string) => {
     return ipcRenderer.invoke("tabs:new-tab", url, isForeground, spaceId);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -237,6 +237,10 @@ const tabsAPI: FlowTabsAPI = {
     return ipcRenderer.send("tabs:show-context-menu", tabId);
   },
 
+  moveTab: async (tabId: number, newPosition: number) => {
+    return ipcRenderer.invoke("tabs:move-tab", tabId, newPosition);
+  },
+
   // Special Exception: This is allowed for all internal protocols.
   newTab: async (url?: string, isForeground?: boolean, spaceId?: string) => {
     return ipcRenderer.invoke("tabs:new-tab", url, isForeground, spaceId);

--- a/src/renderer/src/components/browser-ui/browser-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/browser-sidebar.tsx
@@ -32,6 +32,7 @@ type BrowserSidebarProps = {
 
 export const SIDEBAR_HOVER_COLOR =
   "hover:bg-black/10 active:bg-black/15 dark:hover:bg-white/10 dark:active:bg-white/15";
+export const SIDEBAR_HOVER_COLOR_PLAIN = "bg-black/10 dark:bg-white/10";
 
 // Custom hook to handle sidebar animation mounting logic
 function useSidebarAnimation(shouldRenderContent: boolean, setVariant: (variant: SidebarVariant) => void) {

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
@@ -30,10 +30,6 @@ export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggest
 
       const newPos = biggestIndex + 1;
 
-      if (newPos !== undefined) {
-        moveTab(sourceTabId, newPos);
-      }
-
       if (sourceData.spaceId != spaceData.id) {
         if (sourceData.profileId != spaceData.profileId) {
           // TODO: @MOVE_TABS_BETWEEN_PROFILES not supported yet
@@ -41,6 +37,8 @@ export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggest
           // move tab to new space
           flow.tabs.moveTabToWindowSpace(sourceTabId, spaceData.id, newPos);
         }
+      } else {
+        moveTab(sourceTabId, newPos);
       }
     }
 

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
@@ -30,7 +30,7 @@ export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggest
 
       const newPos = biggestIndex + 1;
 
-      if (newPos) {
+      if (newPos !== undefined) {
         moveTab(sourceTabId, newPos);
       }
 

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
@@ -1,0 +1,81 @@
+import { TabGroupSourceData } from "@/components/browser-ui/sidebar/content/sidebar-tab-groups";
+import { DropIndicator } from "@/components/browser-ui/sidebar/content/space-sidebar";
+import { useEffect, useRef, useState } from "react";
+import { Space } from "~/flow/interfaces/sessions/spaces";
+import {
+  dropTargetForElements,
+  ElementDropTargetEventBasePayload
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+
+type SidebarTabDropTargetProps = {
+  spaceData: Space;
+  isSpaceLight: boolean;
+  moveTab: (tabId: number, newPos: number) => void;
+  biggestIndex: number;
+};
+
+export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggestIndex }: SidebarTabDropTargetProps) {
+  const [showDropIndicator, setShowDropIndicator] = useState(false);
+  const dropTargetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = dropTargetRef.current;
+    if (!el) return () => {};
+
+    function onDrop(args: ElementDropTargetEventBasePayload) {
+      setShowDropIndicator(false);
+
+      const sourceData = args.source.data as TabGroupSourceData;
+      const sourceTabId = sourceData.primaryTabId;
+
+      const newPos = biggestIndex + 1;
+
+      if (newPos) {
+        moveTab(sourceTabId, newPos);
+      }
+
+      if (sourceData.spaceId != spaceData.id) {
+        if (sourceData.profileId != spaceData.profileId) {
+          // TODO: @MOVE_TABS_BETWEEN_PROFILES not supported yet
+        } else {
+          // move tab to new space
+          flow.tabs.moveTabToWindowSpace(sourceTabId, spaceData.id, newPos);
+        }
+      }
+    }
+
+    function onChange() {
+      setShowDropIndicator(true);
+    }
+
+    const cleanupDropTarget = dropTargetForElements({
+      element: el,
+      canDrop: (args) => {
+        const sourceData = args.source.data as TabGroupSourceData;
+        if (sourceData.type !== "tab-group") {
+          return false;
+        }
+
+        if (sourceData.profileId !== spaceData.profileId) {
+          // TODO: @MOVE_TABS_BETWEEN_PROFILES not supported yet
+          return false;
+        }
+
+        return true;
+      },
+      onDrop: onDrop,
+      onDragEnter: onChange,
+      onDrag: onChange,
+      onDragLeave: () => setShowDropIndicator(false)
+    });
+
+    return cleanupDropTarget;
+  }, [spaceData.profileId, isSpaceLight, moveTab, biggestIndex, spaceData.id]);
+
+  return (
+    <>
+      {showDropIndicator && <DropIndicator isSpaceLight={isSpaceLight} />}
+      <div className="flex-1 flex flex-col" ref={dropTargetRef}></div>
+    </>
+  );
+}

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -187,7 +187,7 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
 type TabGroupSourceData = {
   type: "tab-group";
   tabGroupId: number;
-  order: number;
+  position: number;
 };
 
 export function SidebarTabGroups({
@@ -218,11 +218,11 @@ export function SidebarTabGroups({
 
       const closestEdge = extractClosestEdge(self.data);
 
-      const sourceOrder = sourceData.order;
-      const thisOrder = tabGroup.order;
+      const sourcePosition = sourceData.position;
+      const thisPosition = tabGroup.position;
 
-      const isItemBeforeSource = thisOrder === sourceOrder - 1;
-      const isItemAfterSource = thisOrder === sourceOrder + 1;
+      const isItemBeforeSource = thisPosition === sourcePosition - 1;
+      const isItemAfterSource = thisPosition === sourcePosition + 1;
 
       const isDropIndicatorHidden =
         (isItemBeforeSource && closestEdge === "bottom") || (isItemAfterSource && closestEdge === "top");
@@ -241,7 +241,7 @@ export function SidebarTabGroups({
         const data: TabGroupSourceData = {
           type: "tab-group",
           tabGroupId: tabGroup.id,
-          order: tabGroup.order
+          position: tabGroup.position
         };
         return data;
       }
@@ -276,7 +276,7 @@ export function SidebarTabGroups({
       draggableCleanup();
       cleanupDropTarget();
     };
-  }, [tabGroup.id, tabGroup.order]);
+  }, [tabGroup.id, tabGroup.position]);
 
   return (
     <>

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -125,7 +125,7 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
                   src={craftActiveFaviconURL(tab.id, tab.faviconURL)}
                   //src={tab.faviconURL || undefined}
                   alt={tab.title}
-                  className="size-full rounded-sm"
+                  className="size-full rounded-sm user-drag-none object-contain overflow-hidden"
                   onError={() => setIsError(true)}
                   onClick={handleClick}
                   onMouseDown={handleMouseDown}
@@ -237,7 +237,7 @@ export function SidebarTabGroups({
         newPos = position + 0.5;
       }
 
-      if (newPos) {
+      if (newPos !== undefined) {
         moveTab(sourceTabId, newPos);
       }
 

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -216,24 +216,8 @@ export function SidebarTabGroups({
     const el = ref.current;
     if (!el) return () => {};
 
-    function onChange({ source, self }: ElementDropTargetEventBasePayload) {
-      const sourceData = source.data as TabGroupSourceData;
+    function onChange({ self }: ElementDropTargetEventBasePayload) {
       const closestEdge = extractClosestEdge(self.data);
-
-      const sourcePosition = sourceData.position;
-      const thisPosition = position;
-
-      const isItemBeforeSource = thisPosition === sourcePosition - 1;
-      const isItemAfterSource = thisPosition === sourcePosition + 1;
-
-      const isDropIndicatorHidden =
-        (isItemBeforeSource && closestEdge === "bottom") || (isItemAfterSource && closestEdge === "top");
-
-      if (isDropIndicatorHidden) {
-        setClosestEdge(null);
-        return;
-      }
-
       setClosestEdge(closestEdge);
     }
 
@@ -259,7 +243,7 @@ export function SidebarTabGroups({
 
       if (sourceData.spaceId != tabGroup.spaceId) {
         if (sourceData.profileId != tabGroup.profileId) {
-          // not supported yet
+          // TODO: @MOVE_TABS_BETWEEN_PROFILES not supported yet
         } else {
           // move tab to new space
           flow.tabs.moveTabToWindowSpace(sourceTabId, tabGroup.spaceId, newPos);
@@ -285,17 +269,16 @@ export function SidebarTabGroups({
     const cleanupDropTarget = dropTargetForElements({
       element: el,
       getData: ({ input, element }) => {
-        // your base data you want to attach to the drop target
-        const data = {
-          tabGroupId: tabGroup.id
-        };
         // this will 'attach' the closest edge to your `data` object
-        return attachClosestEdge(data, {
-          input,
-          element,
-          // you can specify what edges you want to allow the user to be closest to
-          allowedEdges: ["top", "bottom"]
-        });
+        return attachClosestEdge(
+          {},
+          {
+            input,
+            element,
+            // you can specify what edges you want to allow the user to be closest to
+            allowedEdges: ["top", "bottom"]
+          }
+        );
       },
       canDrop: (args) => {
         const sourceData = args.source.data as TabGroupSourceData;
@@ -304,6 +287,11 @@ export function SidebarTabGroups({
         }
 
         if (sourceData.tabGroupId === tabGroup.id) {
+          return false;
+        }
+
+        if (sourceData.profileId !== tabGroup.profileId) {
+          // TODO: @MOVE_TABS_BETWEEN_PROFILES not supported yet
           return false;
         }
 

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -184,6 +184,12 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
   );
 }
 
+type TabGroupSourceData = {
+  type: "tab-group";
+  tabGroupId: number;
+  order: number;
+};
+
 export function SidebarTabGroups({
   tabGroup,
   isFocused,
@@ -204,18 +210,23 @@ export function SidebarTabGroups({
     if (!el) return () => {};
 
     function onChange({ source, self }: ElementDropTargetEventBasePayload) {
-      console.log("onChange", source.element);
+      const sourceData = source.data as TabGroupSourceData;
+      if (sourceData.type !== "tab-group") {
+        setClosestEdge(null);
+        return;
+      }
+
       const closestEdge = extractClosestEdge(self.data);
 
-      // const sourceIndex = source.data.index;
+      const sourceOrder = sourceData.order;
+      const thisOrder = tabGroup.order;
 
-      // const isItemBeforeSource = index === sourceIndex - 1;
-      // const isItemAfterSource = index === sourceIndex + 1;
+      const isItemBeforeSource = thisOrder === sourceOrder - 1;
+      const isItemAfterSource = thisOrder === sourceOrder + 1;
 
-      // const isDropIndicatorHidden =
-      //   (isItemBeforeSource && closestEdge === "bottom") || (isItemAfterSource && closestEdge === "top");
+      const isDropIndicatorHidden =
+        (isItemBeforeSource && closestEdge === "bottom") || (isItemAfterSource && closestEdge === "top");
 
-      const isDropIndicatorHidden = false;
       if (isDropIndicatorHidden) {
         setClosestEdge(null);
         return;
@@ -227,9 +238,12 @@ export function SidebarTabGroups({
     const draggableCleanup = draggable({
       element: el,
       getInitialData: () => {
-        return {
-          tabGroupId: tabGroup.id
+        const data: TabGroupSourceData = {
+          type: "tab-group",
+          tabGroupId: tabGroup.id,
+          order: tabGroup.order
         };
+        return data;
       }
     });
 
@@ -262,7 +276,7 @@ export function SidebarTabGroups({
       draggableCleanup();
       cleanupDropTarget();
     };
-  }, [tabGroup.id]);
+  }, [tabGroup.id, tabGroup.order]);
 
   return (
     <>

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -237,10 +237,6 @@ export function SidebarTabGroups({
         newPos = position + 0.5;
       }
 
-      if (newPos !== undefined) {
-        moveTab(sourceTabId, newPos);
-      }
-
       if (sourceData.spaceId != tabGroup.spaceId) {
         if (sourceData.profileId != tabGroup.profileId) {
           // TODO: @MOVE_TABS_BETWEEN_PROFILES not supported yet
@@ -248,6 +244,8 @@ export function SidebarTabGroups({
           // move tab to new space
           flow.tabs.moveTabToWindowSpace(sourceTabId, tabGroup.spaceId, newPos);
         }
+      } else if (newPos !== undefined) {
+        moveTab(sourceTabId, newPos);
       }
     }
 

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -184,16 +184,18 @@ export function SidebarTabGroups({
   tabGroup: TabGroup;
   isActive: boolean; // isActive might still be needed depending on parent component logic
   isFocused: boolean;
+  isDragging: boolean;
 }) {
   const { tabs, focusedTab } = tabGroup;
 
   return (
     <motion.div
+      dragSnapToOrigin={true}
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       layout
-      className="space-y-0.5" // Removed split mode specific padding and background
+      className={cn("space-y-0.5")}
     >
       {tabs.map((tab) => (
         <SidebarTab key={tab.id} tab={tab} isFocused={isFocused && focusedTab?.id === tab.id} />

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -6,18 +6,16 @@ import { Button } from "@/components/ui/button";
 import { SidebarGroup, SidebarMenu } from "@/components/ui/resizable-sidebar";
 import { Space } from "@/lib/flow/interfaces/sessions/spaces";
 import { cn, hex_is_light } from "@/lib/utils";
-import { AnimatePresence, Reorder } from "motion/react";
+import { AnimatePresence, Reorder, motion } from "motion/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
-function SidebarSectionDivider({
-  showClearButton,
-  handleCloseAllTabs
-}: {
-  showClearButton: boolean;
-  handleCloseAllTabs: () => void;
-}) {
+const ENABLE_SECTION_DEVIDER = false;
+
+function SidebarSectionDivider({ hasTabs, handleCloseAllTabs }: { hasTabs: boolean; handleCloseAllTabs: () => void }) {
+  if (!hasTabs) return null;
+
   return (
-    <div
+    <motion.div
       className={cn(
         "flex flex-row",
         "items-center justify-between",
@@ -25,24 +23,26 @@ function SidebarSectionDivider({
         "h-1 gap-1",
         "mt-0" // mt-0 is temporary, just for right now before pinned tabs releases
       )}
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      transition={{ duration: 0.2 }}
     >
       <div className={cn("h-[1px] flex-grow", "bg-black/10 dark:bg-white/25")} />
-      {showClearButton && (
-        <Button
-          className={cn(
-            "h-1 !p-1 rounded-sm",
-            "text-black/50 dark:text-white/50",
-            "hover:text-black/80 dark:hover:text-white/80",
-            "hover:bg-transparent hover:dark:bg-transparent"
-          )}
-          variant="ghost"
-          size="sm"
-          onClick={handleCloseAllTabs}
-        >
-          <span className="text-xs font-semibold">Clear</span>
-        </Button>
-      )}
-    </div>
+      <Button
+        className={cn(
+          "h-1 !p-1 rounded-sm",
+          "text-black/50 dark:text-white/50",
+          "hover:text-black/80 dark:hover:text-white/80",
+          "hover:bg-transparent hover:dark:bg-transparent"
+        )}
+        variant="ghost"
+        size="sm"
+        onClick={handleCloseAllTabs}
+      >
+        <span className="text-xs font-semibold">Clear</span>
+      </Button>
+    </motion.div>
   );
 }
 
@@ -84,14 +84,18 @@ export function SpaceSidebar({ space }: { space: Space }) {
 
   const [draggingTabGroup, setDraggingTabGroup] = useState<number | null>(null);
 
-  const showClearButton = tabGroups.length > 0;
+  const hasTabs = tabGroups.length > 0;
 
   return (
     <div className={cn(isSpaceLight ? "" : "dark", "h-full")} ref={sidebarRef}>
       <SpaceTitle space={space} />
-      <SidebarGroup>
+      <SidebarGroup className="py-0.5">
         <SidebarMenu>
-          <SidebarSectionDivider showClearButton={showClearButton} handleCloseAllTabs={handleCloseAllTabs} />
+          {ENABLE_SECTION_DEVIDER && (
+            <AnimatePresence>
+              {hasTabs && <SidebarSectionDivider hasTabs={hasTabs} handleCloseAllTabs={handleCloseAllTabs} />}
+            </AnimatePresence>
+          )}
           <NewTabButton />
           <Reorder.Group
             as="div"
@@ -100,7 +104,7 @@ export function SpaceSidebar({ space }: { space: Space }) {
             values={sortedTabGroups.map((tabGroup) => tabGroup.id)}
             axis="y"
           >
-            <div className="flex flex-col justify-between gap-0.5">
+            <div className="flex flex-col justify-between gap-1">
               <AnimatePresence initial={false}>
                 {sortedTabGroups.map((tabGroup) => (
                   <Reorder.Item

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -105,15 +105,17 @@ export function SpaceSidebar({ space }: { space: Space }) {
           <NewTabButton />
           <div className="flex flex-col justify-between gap-1">
             <AnimatePresence initial={false}>
-              {tabGroups.map((tabGroup) => (
-                <SidebarTabGroups
-                  key={tabGroup.id}
-                  tabGroup={tabGroup}
-                  isActive={activeTabGroup?.id === tabGroup.id || false}
-                  isFocused={!!focusedTab && tabGroup.tabs.some((tab) => tab.id === focusedTab.id)}
-                  isSpaceLight={isSpaceLight}
-                />
-              ))}
+              {tabGroups
+                .sort((a, b) => a.order - b.order)
+                .map((tabGroup) => (
+                  <SidebarTabGroups
+                    key={tabGroup.id}
+                    tabGroup={tabGroup}
+                    isActive={activeTabGroup?.id === tabGroup.id || false}
+                    isFocused={!!focusedTab && tabGroup.tabs.some((tab) => tab.id === focusedTab.id)}
+                    isSpaceLight={isSpaceLight}
+                  />
+                ))}
             </AnimatePresence>
           </div>
         </SidebarMenu>

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -9,6 +9,7 @@ import { cn, hex_is_light } from "@/lib/utils";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useRef } from "react";
 import { DropIndicator as BaseDropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/list-item";
+import { SidebarTabDropTarget } from "@/components/browser-ui/sidebar/content/sidebar-tab-drop-target";
 
 const ENABLE_SECTION_DEVIDER = true;
 
@@ -120,17 +121,17 @@ export function SpaceSidebar({ space }: { space: Space }) {
   );
 
   return (
-    <div className={cn(isSpaceLight ? "" : "dark", "h-full")} ref={sidebarRef}>
+    <div className={cn(isSpaceLight ? "" : "dark", "h-full flex flex-col")} ref={sidebarRef}>
       <SpaceTitle space={space} />
-      <SidebarGroup className="py-0.5">
-        <SidebarMenu>
+      <SidebarGroup className="py-0.5 flex-1">
+        <SidebarMenu className="flex-1">
           {ENABLE_SECTION_DEVIDER && (
             <AnimatePresence>
               {hasTabs && <SidebarSectionDivider hasTabs={hasTabs} handleCloseAllTabs={handleCloseAllTabs} />}
             </AnimatePresence>
           )}
           <NewTabButton />
-          <div className="flex flex-col justify-between gap-1">
+          <div className="flex-1 flex flex-col justify-between gap-1">
             <AnimatePresence initial={false}>
               {sortedTabGroups.map((tabGroup, index) => (
                 <SidebarTabGroups
@@ -143,6 +144,12 @@ export function SpaceSidebar({ space }: { space: Space }) {
                   moveTab={moveTab}
                 />
               ))}
+              <SidebarTabDropTarget
+                spaceData={space}
+                isSpaceLight={isSpaceLight}
+                moveTab={moveTab}
+                biggestIndex={sortedTabGroups.length - 1}
+              />
             </AnimatePresence>
           </div>
         </SidebarMenu>

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -3,11 +3,11 @@ import { SidebarTabGroups } from "@/components/browser-ui/sidebar/content/sideba
 import { SpaceTitle } from "@/components/browser-ui/sidebar/content/space-title";
 import { useTabs } from "@/components/providers/tabs-provider";
 import { Button } from "@/components/ui/button";
-import { SidebarGroup, SidebarMenu } from "@/components/ui/resizable-sidebar";
+import { SidebarGroup, SidebarMenu, useSidebar } from "@/components/ui/resizable-sidebar";
 import { Space } from "@/lib/flow/interfaces/sessions/spaces";
 import { cn, hex_is_light } from "@/lib/utils";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { DropIndicator as BaseDropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/list-item";
 import { SidebarTabDropTarget } from "@/components/browser-ui/sidebar/content/sidebar-tab-drop-target";
 
@@ -37,30 +37,34 @@ export function DropIndicator({ isSpaceLight }: { isSpaceLight: boolean }) {
 }
 
 function SidebarSectionDivider({ hasTabs, handleCloseAllTabs }: { hasTabs: boolean; handleCloseAllTabs: () => void }) {
+  const { open } = useSidebar();
+
   if (!hasTabs) return null;
 
   return (
     <motion.div
-      className={cn("flex flex-row", "items-center justify-between", "mx-1 my-3", "h-1 gap-1")}
+      className={cn("flex flex-row", "items-center justify-between", "h-1 gap-1", open ? "mx-1 my-3" : "mx-1 my-1")}
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}
       transition={{ duration: 0.2 }}
     >
       <div className={cn("h-[1px] flex-grow", "bg-black/10 dark:bg-white/25")} />
-      <Button
-        className={cn(
-          "h-1 !p-1 rounded-sm",
-          "text-black/50 dark:text-white/50",
-          "hover:text-black/80 dark:hover:text-white/80",
-          "hover:bg-transparent hover:dark:bg-transparent"
-        )}
-        variant="ghost"
-        size="sm"
-        onClick={handleCloseAllTabs}
-      >
-        <span className="text-xs font-semibold">Clear</span>
-      </Button>
+      {open && (
+        <Button
+          className={cn(
+            "h-1 !p-1 rounded-sm",
+            "text-black/50 dark:text-white/50",
+            "hover:text-black/80 dark:hover:text-white/80",
+            "hover:bg-transparent hover:dark:bg-transparent"
+          )}
+          variant="ghost"
+          size="sm"
+          onClick={handleCloseAllTabs}
+        >
+          <span className="text-xs font-semibold">Clear</span>
+        </Button>
+      )}
     </motion.div>
   );
 }
@@ -93,12 +97,13 @@ export function SpaceSidebar({ space }: { space: Space }) {
 
   const hasTabs = tabGroups.length > 0;
 
-  const sortedTabGroups = [...tabGroups].sort((a, b) => a.position - b.position);
+  const sortedTabGroups = useMemo(() => {
+    return [...tabGroups].sort((a, b) => a.position - b.position);
+  }, [tabGroups]);
 
   const moveTab = useCallback(
     (tabId: number, newPosition: number) => {
-      const newSortedTabGroups = [...sortedTabGroups].sort((a, b) => a.position - b.position);
-      newSortedTabGroups.sort((a, b) => {
+      const newSortedTabGroups = [...sortedTabGroups].sort((a, b) => {
         const isTabInGroupA = a.tabs.some((tab) => tab.id === tabId);
         const isTabInGroupB = b.tabs.some((tab) => tab.id === tabId);
 

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -92,6 +92,33 @@ export function SpaceSidebar({ space }: { space: Space }) {
 
   const hasTabs = tabGroups.length > 0;
 
+  const sortedTabGroups = [...tabGroups].sort((a, b) => a.position - b.position);
+
+  const moveTab = useCallback(
+    (tabId: number, newPosition: number) => {
+      const newSortedTabGroups = [...sortedTabGroups].sort((a, b) => a.position - b.position);
+      newSortedTabGroups.sort((a, b) => {
+        const isTabInGroupA = a.tabs.some((tab) => tab.id === tabId);
+        const isTabInGroupB = b.tabs.some((tab) => tab.id === tabId);
+
+        const aIndex = newSortedTabGroups.findIndex((tabGroup) => tabGroup.id === a.id);
+        const bIndex = newSortedTabGroups.findIndex((tabGroup) => tabGroup.id === b.id);
+
+        const aPos = isTabInGroupA ? newPosition : aIndex;
+        const bPos = isTabInGroupB ? newPosition : bIndex;
+
+        return aPos - bPos;
+      });
+
+      for (const [index, tabGroup] of newSortedTabGroups.entries()) {
+        if (tabGroup.position !== index) {
+          flow.tabs.moveTab(tabGroup.tabs[0].id, index);
+        }
+      }
+    },
+    [sortedTabGroups]
+  );
+
   return (
     <div className={cn(isSpaceLight ? "" : "dark", "h-full")} ref={sidebarRef}>
       <SpaceTitle space={space} />
@@ -105,17 +132,17 @@ export function SpaceSidebar({ space }: { space: Space }) {
           <NewTabButton />
           <div className="flex flex-col justify-between gap-1">
             <AnimatePresence initial={false}>
-              {tabGroups
-                .sort((a, b) => a.position - b.position)
-                .map((tabGroup) => (
-                  <SidebarTabGroups
-                    key={tabGroup.id}
-                    tabGroup={tabGroup}
-                    isActive={activeTabGroup?.id === tabGroup.id || false}
-                    isFocused={!!focusedTab && tabGroup.tabs.some((tab) => tab.id === focusedTab.id)}
-                    isSpaceLight={isSpaceLight}
-                  />
-                ))}
+              {sortedTabGroups.map((tabGroup, index) => (
+                <SidebarTabGroups
+                  key={tabGroup.id}
+                  tabGroup={tabGroup}
+                  isActive={activeTabGroup?.id === tabGroup.id || false}
+                  isFocused={!!focusedTab && tabGroup.tabs.some((tab) => tab.id === focusedTab.id)}
+                  isSpaceLight={isSpaceLight}
+                  position={index}
+                  moveTab={moveTab}
+                />
+              ))}
             </AnimatePresence>
           </div>
         </SidebarMenu>

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -6,10 +6,34 @@ import { Button } from "@/components/ui/button";
 import { SidebarGroup, SidebarMenu } from "@/components/ui/resizable-sidebar";
 import { Space } from "@/lib/flow/interfaces/sessions/spaces";
 import { cn, hex_is_light } from "@/lib/utils";
-import { AnimatePresence, Reorder, motion } from "motion/react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useCallback, useRef } from "react";
+import { DropIndicator as BaseDropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/list-item";
 
 const ENABLE_SECTION_DEVIDER = true;
+
+export function DropIndicator({ isSpaceLight }: { isSpaceLight: boolean }) {
+  return (
+    <ol
+      className="flex *:mx-2 relative h-0 -m-0.5"
+      style={
+        {
+          "--ds-border-selected": isSpaceLight ? "#000" : "#fff"
+        } as React.CSSProperties
+      }
+    >
+      <BaseDropIndicator
+        instruction={{
+          axis: "vertical",
+          operation: "reorder-after",
+          blocked: false
+        }}
+        lineGap="0px"
+        lineType="terminal-no-bleed"
+      />
+    </ol>
+  );
+}
 
 function SidebarSectionDivider({ hasTabs, handleCloseAllTabs }: { hasTabs: boolean; handleCloseAllTabs: () => void }) {
   if (!hasTabs) return null;
@@ -66,18 +90,6 @@ export function SpaceSidebar({ space }: { space: Space }) {
 
   const sidebarRef = useRef<HTMLDivElement>(null);
 
-  const [tabGroupsOrder, setTabGroupsOrder] = useState<number[]>([]);
-  const handleReorder = (newOrder: number[]) => {
-    console.log("newOrder", newOrder);
-    setTabGroupsOrder(newOrder);
-  };
-
-  const sortedTabGroups = useMemo(() => {
-    return tabGroups.sort((a, b) => tabGroupsOrder.indexOf(a.id) - tabGroupsOrder.indexOf(b.id));
-  }, [tabGroups, tabGroupsOrder]);
-
-  const [draggingTabGroup, setDraggingTabGroup] = useState<number | null>(null);
-
   const hasTabs = tabGroups.length > 0;
 
   return (
@@ -91,36 +103,19 @@ export function SpaceSidebar({ space }: { space: Space }) {
             </AnimatePresence>
           )}
           <NewTabButton />
-          <Reorder.Group
-            as="div"
-            layout
-            onReorder={handleReorder}
-            values={sortedTabGroups.map((tabGroup) => tabGroup.id)}
-            axis="y"
-          >
-            <div className="flex flex-col justify-between gap-1">
-              <AnimatePresence initial={false}>
-                {sortedTabGroups.map((tabGroup) => (
-                  <Reorder.Item
-                    key={tabGroup.id}
-                    value={tabGroup.id}
-                    dragConstraints={sidebarRef}
-                    dragElastic={0}
-                    dragSnapToOrigin={true}
-                    onDragStart={() => setDraggingTabGroup(tabGroup.id)}
-                    onDragEnd={() => setDraggingTabGroup(null)}
-                  >
-                    <SidebarTabGroups
-                      tabGroup={tabGroup}
-                      isActive={activeTabGroup?.id === tabGroup.id || false}
-                      isFocused={!!focusedTab && tabGroup.tabs.some((tab) => tab.id === focusedTab.id)}
-                      isDragging={draggingTabGroup === tabGroup.id}
-                    />
-                  </Reorder.Item>
-                ))}
-              </AnimatePresence>
-            </div>
-          </Reorder.Group>
+          <div className="flex flex-col justify-between gap-1">
+            <AnimatePresence initial={false}>
+              {tabGroups.map((tabGroup) => (
+                <SidebarTabGroups
+                  key={tabGroup.id}
+                  tabGroup={tabGroup}
+                  isActive={activeTabGroup?.id === tabGroup.id || false}
+                  isFocused={!!focusedTab && tabGroup.tabs.some((tab) => tab.id === focusedTab.id)}
+                  isSpaceLight={isSpaceLight}
+                />
+              ))}
+            </AnimatePresence>
+          </div>
         </SidebarMenu>
       </SidebarGroup>
     </div>

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -9,20 +9,14 @@ import { cn, hex_is_light } from "@/lib/utils";
 import { AnimatePresence, Reorder, motion } from "motion/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
-const ENABLE_SECTION_DEVIDER = false;
+const ENABLE_SECTION_DEVIDER = true;
 
 function SidebarSectionDivider({ hasTabs, handleCloseAllTabs }: { hasTabs: boolean; handleCloseAllTabs: () => void }) {
   if (!hasTabs) return null;
 
   return (
     <motion.div
-      className={cn(
-        "flex flex-row",
-        "items-center justify-between",
-        "mx-1 my-2",
-        "h-1 gap-1",
-        "mt-0" // mt-0 is temporary, just for right now before pinned tabs releases
-      )}
+      className={cn("flex flex-row", "items-center justify-between", "mx-1 my-3", "h-1 gap-1")}
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -1,14 +1,50 @@
-import { SIDEBAR_HOVER_COLOR } from "@/components/browser-ui/browser-sidebar";
 import { NewTabButton } from "@/components/browser-ui/sidebar/content/new-tab-button";
 import { SidebarTabGroups } from "@/components/browser-ui/sidebar/content/sidebar-tab-groups";
 import { SpaceTitle } from "@/components/browser-ui/sidebar/content/space-title";
 import { useTabs } from "@/components/providers/tabs-provider";
-import { SidebarGroup, SidebarGroupAction, SidebarGroupLabel, SidebarMenu } from "@/components/ui/resizable-sidebar";
+import { Button } from "@/components/ui/button";
+import { SidebarGroup, SidebarMenu } from "@/components/ui/resizable-sidebar";
 import { Space } from "@/lib/flow/interfaces/sessions/spaces";
 import { cn, hex_is_light } from "@/lib/utils";
-import { Trash2Icon } from "lucide-react";
 import { AnimatePresence, Reorder } from "motion/react";
 import { useCallback, useMemo, useRef, useState } from "react";
+
+function SidebarSectionDivider({
+  showClearButton,
+  handleCloseAllTabs
+}: {
+  showClearButton: boolean;
+  handleCloseAllTabs: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-row",
+        "items-center justify-between",
+        "mx-1 my-2",
+        "h-1 gap-1",
+        "mt-0" // mt-0 is temporary, just for right now before pinned tabs releases
+      )}
+    >
+      <div className={cn("h-[1px] flex-grow", "bg-black/10 dark:bg-white/25")} />
+      {showClearButton && (
+        <Button
+          className={cn(
+            "h-1 !p-1 rounded-sm",
+            "text-black/50 dark:text-white/50",
+            "hover:text-black/80 dark:hover:text-white/80",
+            "hover:bg-transparent hover:dark:bg-transparent"
+          )}
+          variant="ghost"
+          size="sm"
+          onClick={handleCloseAllTabs}
+        >
+          <span className="text-xs font-semibold">Clear</span>
+        </Button>
+      )}
+    </div>
+  );
+}
 
 export function SpaceSidebar({ space }: { space: Space }) {
   const { getTabGroups, getActiveTabGroup, getFocusedTab } = useTabs();
@@ -48,44 +84,45 @@ export function SpaceSidebar({ space }: { space: Space }) {
 
   const [draggingTabGroup, setDraggingTabGroup] = useState<number | null>(null);
 
+  const showClearButton = tabGroups.length > 0;
+
   return (
     <div className={cn(isSpaceLight ? "" : "dark", "h-full")} ref={sidebarRef}>
       <SpaceTitle space={space} />
       <SidebarGroup>
-        <SidebarGroupLabel className="font-medium text-black dark:text-white">Tabs</SidebarGroupLabel>
-        <SidebarGroupAction onClick={handleCloseAllTabs} className={cn(SIDEBAR_HOVER_COLOR, "size-6")}>
-          <Trash2Icon className="size-1.5 m-1 text-black dark:text-white" />
-        </SidebarGroupAction>
         <SidebarMenu>
+          <SidebarSectionDivider showClearButton={showClearButton} handleCloseAllTabs={handleCloseAllTabs} />
           <NewTabButton />
-          <AnimatePresence initial={false}>
-            <Reorder.Group
-              as="div"
-              layout
-              onReorder={handleReorder}
-              values={sortedTabGroups.map((tabGroup) => tabGroup.id)}
-              axis="y"
-            >
-              {sortedTabGroups.map((tabGroup) => (
-                <Reorder.Item
-                  key={tabGroup.id}
-                  value={tabGroup.id}
-                  dragConstraints={sidebarRef}
-                  dragElastic={0}
-                  dragSnapToOrigin={true}
-                  onDragStart={() => setDraggingTabGroup(tabGroup.id)}
-                  onDragEnd={() => setDraggingTabGroup(null)}
-                >
-                  <SidebarTabGroups
-                    tabGroup={tabGroup}
-                    isActive={activeTabGroup?.id === tabGroup.id || false}
-                    isFocused={!!focusedTab && tabGroup.tabs.some((tab) => tab.id === focusedTab.id)}
-                    isDragging={draggingTabGroup === tabGroup.id}
-                  />
-                </Reorder.Item>
-              ))}
-            </Reorder.Group>
-          </AnimatePresence>
+          <Reorder.Group
+            as="div"
+            layout
+            onReorder={handleReorder}
+            values={sortedTabGroups.map((tabGroup) => tabGroup.id)}
+            axis="y"
+          >
+            <div className="flex flex-col justify-between gap-0.5">
+              <AnimatePresence initial={false}>
+                {sortedTabGroups.map((tabGroup) => (
+                  <Reorder.Item
+                    key={tabGroup.id}
+                    value={tabGroup.id}
+                    dragConstraints={sidebarRef}
+                    dragElastic={0}
+                    dragSnapToOrigin={true}
+                    onDragStart={() => setDraggingTabGroup(tabGroup.id)}
+                    onDragEnd={() => setDraggingTabGroup(null)}
+                  >
+                    <SidebarTabGroups
+                      tabGroup={tabGroup}
+                      isActive={activeTabGroup?.id === tabGroup.id || false}
+                      isFocused={!!focusedTab && tabGroup.tabs.some((tab) => tab.id === focusedTab.id)}
+                      isDragging={draggingTabGroup === tabGroup.id}
+                    />
+                  </Reorder.Item>
+                ))}
+              </AnimatePresence>
+            </div>
+          </Reorder.Group>
         </SidebarMenu>
       </SidebarGroup>
     </div>

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -106,7 +106,7 @@ export function SpaceSidebar({ space }: { space: Space }) {
           <div className="flex flex-col justify-between gap-1">
             <AnimatePresence initial={false}>
               {tabGroups
-                .sort((a, b) => a.order - b.order)
+                .sort((a, b) => a.position - b.position)
                 .map((tabGroup) => (
                   <SidebarTabGroups
                     key={tabGroup.id}

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-title.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-title.tsx
@@ -8,7 +8,7 @@ export function SpaceTitle({ space }: { space: Space }) {
   if (!open) return null;
 
   return (
-    <SidebarGroup>
+    <SidebarGroup className="py-0.5">
       <SidebarMenuButton className="!opacity-100" disabled>
         <SpaceIcon fallbackId={undefined} id={space.icon} strokeWidth={2.5} className="text-black dark:text-white" />
         <span className="font-bold text-black dark:text-white">{space.name}</span>

--- a/src/renderer/src/components/browser-ui/sidebar/spaces-switcher.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/spaces-switcher.tsx
@@ -19,6 +19,10 @@ function SpaceButton({ space, isActive }: SpaceButtonProps) {
   const ref = useRef<HTMLButtonElement>(null);
 
   const [dragging, setDragging] = useState(false);
+
+  const draggingRef = useRef(false);
+  draggingRef.current = dragging;
+
   const draggingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const onClick = useCallback(() => {
@@ -39,6 +43,7 @@ function SpaceButton({ space, isActive }: SpaceButtonProps) {
     if (!element) return;
 
     function startDragging() {
+      if (draggingRef.current) return;
       setDragging(true);
 
       if (!draggingTimeoutRef.current) {

--- a/src/renderer/src/components/browser-ui/sidebar/spaces-switcher.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/spaces-switcher.tsx
@@ -61,6 +61,12 @@ function SpaceButton({ space, isActive }: SpaceButtonProps) {
         const sourceData = args.source.data as TabGroupSourceData;
         if (sourceData.type !== "tab-group") return false;
 
+        const sourceProfileId = sourceData.profileId;
+        const targetProfileId = space.profileId;
+
+        // TODO: @MOVE_TABS_BETWEEN_PROFILES Does not support moving tabs between profiles
+        if (sourceProfileId !== targetProfileId) return false;
+
         return true;
       },
       onDragEnter: startDragging,
@@ -68,7 +74,7 @@ function SpaceButton({ space, isActive }: SpaceButtonProps) {
       onDragLeave: stopDragging,
       onDrop: stopDragging
     });
-  }, [onClick, removeDraggingTimeout]);
+  }, [onClick, removeDraggingTimeout, space.profileId]);
 
   return (
     <SidebarMenuButton

--- a/src/renderer/src/components/providers/tabs-provider.tsx
+++ b/src/renderer/src/components/providers/tabs-provider.tsx
@@ -111,7 +111,7 @@ export const TabsProvider = ({ children }: TabsProviderProps) => {
         profileId: tab.profileId,
         spaceId: tab.spaceId,
         tabIds: [tab.id],
-        order: tab.order
+        position: tab.position
       });
     }
 

--- a/src/renderer/src/components/providers/tabs-provider.tsx
+++ b/src/renderer/src/components/providers/tabs-provider.tsx
@@ -110,7 +110,8 @@ export const TabsProvider = ({ children }: TabsProviderProps) => {
         mode: "normal",
         profileId: tab.profileId,
         spaceId: tab.spaceId,
-        tabIds: [tab.id]
+        tabIds: [tab.id],
+        order: tab.order
       });
     }
 

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -68,6 +68,10 @@
   -webkit-app-region: no-drag;
 }
 
+.user-drag-none {
+  -webkit-user-drag: none;
+}
+
 .dark {
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);

--- a/src/shared/flow/interfaces/browser/tabs.ts
+++ b/src/shared/flow/interfaces/browser/tabs.ts
@@ -53,4 +53,11 @@ export interface FlowTabsAPI {
    * @param muted Whether the tab should be muted
    */
   setTabMuted: (tabId: number, muted: boolean) => Promise<boolean>;
+
+  /**
+   * Move a tab to a new position
+   * @param tabId The id of the tab to move
+   * @param newPosition The new position of the tab
+   */
+  moveTab: (tabId: number, newPosition: number) => Promise<boolean>;
 }

--- a/src/shared/flow/interfaces/browser/tabs.ts
+++ b/src/shared/flow/interfaces/browser/tabs.ts
@@ -60,4 +60,12 @@ export interface FlowTabsAPI {
    * @param newPosition The new position of the tab
    */
   moveTab: (tabId: number, newPosition: number) => Promise<boolean>;
+
+  /**
+   * Move a tab to a new space
+   * @param tabId The id of the tab to move
+   * @param spaceId The id of the space to move the tab to
+   * @param newPosition The new position of the tab
+   */
+  moveTabToWindowSpace: (tabId: number, spaceId: string, newPosition?: number) => Promise<boolean>;
 }

--- a/src/shared/types/tabs.ts
+++ b/src/shared/types/tabs.ts
@@ -10,6 +10,7 @@ export type TabData = {
   uniqueId: string;
   createdAt: number;
   lastActiveAt: number;
+  order: number;
 
   profileId: string;
   spaceId: string;
@@ -36,6 +37,7 @@ export type TabGroupData = {
   spaceId: string;
   tabIds: number[];
   glanceFrontTabId?: number;
+  order: number;
 };
 
 export type WindowFocusedTabIds = {

--- a/src/shared/types/tabs.ts
+++ b/src/shared/types/tabs.ts
@@ -10,7 +10,7 @@ export type TabData = {
   uniqueId: string;
   createdAt: number;
   lastActiveAt: number;
-  order: number;
+  position: number;
 
   profileId: string;
   spaceId: string;
@@ -37,7 +37,7 @@ export type TabGroupData = {
   spaceId: string;
   tabIds: number[];
   glanceFrontTabId?: number;
-  order: number;
+  position: number;
 };
 
 export type WindowFocusedTabIds = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added drag-and-drop support for reordering and moving tabs and tab groups within the sidebar.
  - Introduced the ability to move tabs between spaces and windows, including cross-space drag-and-drop.
  - Added visual drop indicators and animated section dividers in the sidebar for improved user feedback.
  - Added new tab movement controls accessible via sidebar and API methods.

- **Enhancements**
  - Tabs and tab groups now maintain a persistent position property for accurate ordering.
  - Sidebar UI updated with clearer controls for tab management, including a "Clear" button for closing all tabs.
  - Improved tab creation logic to position new tabs before existing ones by default.
  - Sidebar spaces switcher enhanced with drag-and-drop interaction and internal click handling.

- **Style**
  - Improved sidebar hover and drop indicator visuals for both light and dark modes.
  - Added CSS class to disable user drag behavior on specific elements for better drag-and-drop experience.

- **Bug Fixes**
  - Ensured tab and tab group positions are preserved and restored correctly across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->