### PR TITLE
Fix Close Tab Button not being vertically aligned

### DIFF
--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -166,12 +166,12 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
           {/* Right side */}
           <div className={cn("flex flex-row items-center gap-0.5", open && "flex-shrink-0")}>
             {/* Close tab button */}
-            <motion.div whileTap={{ scale: 0.95 }}>
+            <motion.div whileTap={{ scale: 0.95 }} className="flex items-center justify-center">
               <Button
                 variant="ghost"
                 size="icon"
                 onClick={handleCloseTab}
-                className="size-5 bg-transparent rounded-sm hover:bg-black/10 dark:hover:bg-white/10"
+                className="size-5 bg-transparent rounded-sm hover:bg-black/10 dark:hover:bg-white/10 flex items-center justify-center"
                 onMouseDown={(event) => event.stopPropagation()}
               >
                 <XIcon className="size-4 text-muted-foreground dark:text-white" />


### PR DESCRIPTION

Before:
![image](https://github.com/user-attachments/assets/bf817de3-baae-4d42-a74a-06e78fa04cd0)

After:
![image](https://github.com/user-attachments/assets/e4ddd640-295a-4758-9548-8427eeebc7f9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the alignment and layout of the close tab button in the sidebar for a more visually centered appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->