### PR TITLE
Only show close tab button on hover

### DIFF
--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -20,6 +20,7 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
   const [cachedFaviconUrl, setCachedFaviconUrl] = useState<string | null>(tab.faviconURL);
   const [isError, setIsError] = useState(false);
   const [isPressed, setIsPressed] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
   const noFavicon = !cachedFaviconUrl || isError;
 
   const isMuted = tab.muted;
@@ -89,6 +90,8 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
     <MotionSidebarMenuButton
       key={tab.id}
       onContextMenu={handleContextMenu}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       className={cn(
         "bg-transparent active:bg-transparent",
         !isFocused && "hover:bg-black/5 hover:dark:bg-white/10",
@@ -166,7 +169,7 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
           {/* Right side */}
           <div className={cn("flex flex-row items-center gap-0.5", open && "flex-shrink-0")}>
             {/* Close tab button */}
-            <motion.div whileTap={{ scale: 0.95 }}>
+            {isHovered && (
               <Button
                 variant="ghost"
                 size="icon"
@@ -176,7 +179,7 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
               >
                 <XIcon className="size-4 text-muted-foreground dark:text-white" />
               </Button>
-            </motion.div>
+            )}
           </div>
         </>
       </div>

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -170,15 +170,17 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
           <div className={cn("flex flex-row items-center gap-0.5", open && "flex-shrink-0")}>
             {/* Close tab button */}
             {isHovered && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleCloseTab}
-                className="size-5 bg-transparent rounded-sm hover:bg-black/10 dark:hover:bg-white/10"
-                onMouseDown={(event) => event.stopPropagation()}
-              >
-                <XIcon className="size-4 text-muted-foreground dark:text-white" />
-              </Button>
+              <motion.div whileTap={{ scale: 0.95 }}>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleCloseTab}
+                  className="size-5 bg-transparent rounded-sm hover:bg-black/10 dark:hover:bg-white/10"
+                  onMouseDown={(event) => event.stopPropagation()}
+                >
+                  <XIcon className="size-4 text-muted-foreground dark:text-white" />
+                </Button>
+              </motion.div>
             )}
           </div>
         </>


### PR DESCRIPTION
Similarly to arc, The close button is only shown when the tab is hovered in the sidebar

https://github.com/user-attachments/assets/825053d0-215f-48dd-963d-cf9f370b6e5e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The close tab button in the sidebar now appears only when you hover over a tab, providing a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->