### PR TITLE
Remove lazy loading and add page html files

### DIFF
--- a/src/renderer/about.html
+++ b/src/renderer/about.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/error.html
+++ b/src/renderer/error.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/extensions.html
+++ b/src/renderer/extensions.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/games.html
+++ b/src/renderer/games.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/main-ui.html
+++ b/src/renderer/main-ui.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/new-tab.html
+++ b/src/renderer/new-tab.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/omnibox-debug.html
+++ b/src/renderer/omnibox-debug.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/omnibox.html
+++ b/src/renderer/omnibox.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/onboarding.html
+++ b/src/renderer/onboarding.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/pdf-viewer.html
+++ b/src/renderer/pdf-viewer.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/popup-ui.html
+++ b/src/renderer/popup-ui.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/settings.html
+++ b/src/renderer/settings.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Umami Analytics -->
+    <!-- Very simple, does not collect or store personal data -->
+    <!-- Does not log what websites you visit, or anything similar -->
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    ></script>
+  </body>
+</html>

--- a/src/renderer/src/router/provider.tsx
+++ b/src/renderer/src/router/provider.tsx
@@ -41,7 +41,7 @@ export function RouterProvider({ children }: RouterProviderProps) {
       protocol: location.protocol,
       origin: location.origin,
       hostname: location.hostname,
-      pathname: location.pathname,
+      pathname: "/",
       href: location.href,
       search: location.search,
       hash: location.hash

--- a/src/renderer/src/routes/about/route.tsx
+++ b/src/renderer/src/routes/about/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/error/route.tsx
+++ b/src/renderer/src/routes/error/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/extensions/route.tsx
+++ b/src/renderer/src/routes/extensions/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/games/route.tsx
+++ b/src/renderer/src/routes/games/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/main-ui/route.tsx
+++ b/src/renderer/src/routes/main-ui/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/new-tab/route.tsx
+++ b/src/renderer/src/routes/new-tab/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/omnibox-debug/route.tsx
+++ b/src/renderer/src/routes/omnibox-debug/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/omnibox/route.tsx
+++ b/src/renderer/src/routes/omnibox/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/onboarding/route.tsx
+++ b/src/renderer/src/routes/onboarding/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/pdf-viewer/route.tsx
+++ b/src/renderer/src/routes/pdf-viewer/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/popup-ui/route.tsx
+++ b/src/renderer/src/routes/popup-ui/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }

--- a/src/renderer/src/routes/settings/route.tsx
+++ b/src/renderer/src/routes/settings/route.tsx
@@ -1,14 +1,10 @@
-import { lazy, Suspense } from "react";
 import { RouteConfig } from "./config";
-
-const PageComponent = lazy(() => import("./page"));
+import PageComponent from "./page";
 
 export default function Route() {
   return (
     <RouteConfig.Providers>
-      <Suspense fallback={RouteConfig.Fallback}>
-        <PageComponent />
-      </Suspense>
+      <PageComponent />
     </RouteConfig.Providers>
   );
 }


### PR DESCRIPTION
## Summary
- turn each route into a direct import instead of React.lazy
- force router provider to always report pathname as `/`
- add standalone html files for every page

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684078cb3930832eb57e04009f07705c