### PR TITLE
feat: better asleep tabs

### DIFF
--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -99,11 +99,12 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
         isFocused && "bg-white dark:bg-white/25",
         isFocused && "active:bg-white active:dark:bg-white/25",
         "text-gray-900 dark:text-gray-200",
-        "transition-colors"
+        "transition-colors",
+        tab.asleep && "grayscale"
       )}
       initial={{ opacity: 0, x: -10 }}
       animate={{
-        opacity: 1,
+        opacity: tab.asleep ? 0.5 : 1,
         x: 0,
         scale: isPressed ? 0.985 : 1
       }}


### PR DESCRIPTION
Right now, it's difficult to visually differentiate between active and asleep (unloaded) tabs. This makes it harder to manage multiple tabs efficiently.

I propose adding improved styling for asleep tabs, inspired by [zen-browser-better-unloaded-tabs](https://github.com/Felkazz/zen-browser-better-unloaded-tabs).
This enhancement would:

* Improve overall UX when working with many background tabs.
* Make the tab state more intuitive and accessible, especially for users relying on visual feedback.

| Before  | After |
| ------------- | ------------- |
|  ![Screenshot 2025-06-16 at 11 12 49](https://github.com/user-attachments/assets/58986f30-99bf-44c8-962e-187bf8f740f1) | ![Screenshot 2025-06-16 at 11 12 21](https://github.com/user-attachments/assets/b46823be-8f58-4f88-b274-c2cac588336e) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tabs that are in an asleep state now appear dimmed and grayed out in the sidebar, making it easier to distinguish between active and asleep tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->