### PR TITLE
feat: allow pinch zoom

### DIFF
--- a/src/main/browser/tabs/tab.ts
+++ b/src/main/browser/tabs/tab.ts
@@ -221,6 +221,7 @@ export class Tab extends TypedEventEmitter<TabEvents> {
     // Create WebContentsView
     const webContentsView = createWebContentsView(session, webContentsViewOptions);
     const webContents = webContentsView.webContents;
+
     this.id = webContents.id;
     this.view = webContentsView;
     this.webContents = webContents;
@@ -360,6 +361,11 @@ export class Tab extends TypedEventEmitter<TabEvents> {
     const { webContents, window: tabbedWindow } = this;
 
     const window = tabbedWindow.window;
+
+    // Set zoom level limits when webContents is ready
+    webContents.on("did-finish-load", () => {
+      webContents.setVisualZoomLevelLimits(1, 5);
+    });
 
     // Handle fullscreen events
     webContents.on("enter-html-full-screen", () => {


### PR DESCRIPTION
Introduces pinch-to-zoom functionality, commonly used on macOS trackpads

It enables [webFrame.setVisualZoomLevelLimits](https://www.electronjs.org/docs/latest/api/web-frame#webframesetvisualzoomlevellimitsminimumlevel-maximumlevel) to max 500% zoom.

Example:

https://github.com/user-attachments/assets/20e4f71d-9099-4330-911b-1c5b861e3290



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Zoom level for web content is now limited to a minimum of 1 and a maximum of 5 after loading, providing a consistent and controlled zoom experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->