### PR TITLE
feat: add sidebar as app drag pane

### DIFF
--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
@@ -6,15 +6,17 @@ import {
   dropTargetForElements,
   ElementDropTargetEventBasePayload
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { cn } from "@/lib/utils";
 
 type SidebarTabDropTargetProps = {
   spaceData: Space;
   isSpaceLight: boolean;
   moveTab: (tabId: number, newPos: number) => void;
   biggestIndex: number;
+  className?: string;
 };
 
-export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggestIndex }: SidebarTabDropTargetProps) {
+export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggestIndex, className }: SidebarTabDropTargetProps) {
   const [showDropIndicator, setShowDropIndicator] = useState(false);
   const dropTargetRef = useRef<HTMLDivElement>(null);
 
@@ -77,7 +79,7 @@ export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggest
   return (
     <>
       {showDropIndicator && <DropIndicator isSpaceLight={isSpaceLight} />}
-      <div className="flex-1 flex flex-col" ref={dropTargetRef} onDoubleClick={handleDoubleClick}></div>
+      <div className={cn("flex-1 flex flex-col", className)} ref={dropTargetRef} onDoubleClick={handleDoubleClick}></div>
     </>
   );
 }

--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-drop-target.tsx
@@ -16,7 +16,13 @@ type SidebarTabDropTargetProps = {
   className?: string;
 };
 
-export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggestIndex, className }: SidebarTabDropTargetProps) {
+export function SidebarTabDropTarget({
+  spaceData,
+  isSpaceLight,
+  moveTab,
+  biggestIndex,
+  className
+}: SidebarTabDropTargetProps) {
   const [showDropIndicator, setShowDropIndicator] = useState(false);
   const dropTargetRef = useRef<HTMLDivElement>(null);
 
@@ -79,7 +85,11 @@ export function SidebarTabDropTarget({ spaceData, isSpaceLight, moveTab, biggest
   return (
     <>
       {showDropIndicator && <DropIndicator isSpaceLight={isSpaceLight} />}
-      <div className={cn("flex-1 flex flex-col", className)} ref={dropTargetRef} onDoubleClick={handleDoubleClick}></div>
+      <div
+        className={cn("flex-1 flex flex-col", className)}
+        ref={dropTargetRef}
+        onDoubleClick={handleDoubleClick}
+      ></div>
     </>
   );
 }

--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -154,6 +154,7 @@ export function SpaceSidebar({ space }: { space: Space }) {
                 isSpaceLight={isSpaceLight}
                 moveTab={moveTab}
                 biggestIndex={sortedTabGroups.length - 1}
+                className="app-drag"
               />
             </AnimatePresence>
           </div>


### PR DESCRIPTION
Allows user to drag sidebar to move whole window (area selected with yellow stripes on the screenshot below) - of course these stripes are not part of the PR 😃 

![35329](https://github.com/user-attachments/assets/3168cb47-4ce3-4ad2-9ba8-adfdca0b9ad4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated sidebar drop target to support custom CSS classes for improved styling flexibility.
  - Applied a new CSS class to the sidebar drop target for enhanced drag-and-drop visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->