### PR TITLE
chore: enable umami on production only

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -8,15 +8,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-
-    <!-- Umami Analytics -->
-    <!-- Very simple, does not collect or store personal data -->
-    <!-- Does not log what websites you visit, or anything similar -->
-    <script
-      defer
-      src="/umami.js"
-      data-host-url="https://umami.iamevan.dev"
-      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
-    ></script>
   </body>
 </html>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -75,10 +75,10 @@ function App() {
 
       <QueryParamProvider adapter={WindowHistoryAdapter}>
         <PlatformProvider>
-        <Routes />
-        <Toaster richColors />
-      </PlatformProvider>
-    </QueryParamProvider>
+          <Routes />
+          <Toaster richColors />
+        </PlatformProvider>
+      </QueryParamProvider>
     </>
   );
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,7 +1,8 @@
-import { RouterProvider } from "./router/provider";
-import { Route } from "./router/route";
 import { Toaster } from "sonner";
 import { PlatformProvider } from "@/components/main/platform";
+import { UmamiScriptLoader } from "@/components/analytics/umami";
+import { RouterProvider } from "./router/provider";
+import { Route } from "./router/route";
 import { QueryParamProvider } from "use-query-params";
 import { WindowHistoryAdapter } from "use-query-params/adapters/window";
 
@@ -69,12 +70,16 @@ function Routes() {
 
 function App() {
   return (
-    <QueryParamProvider adapter={WindowHistoryAdapter}>
-      <PlatformProvider>
+    <>
+      <UmamiScriptLoader />
+
+      <QueryParamProvider adapter={WindowHistoryAdapter}>
+        <PlatformProvider>
         <Routes />
         <Toaster richColors />
       </PlatformProvider>
     </QueryParamProvider>
+    </>
   );
 }
 

--- a/src/renderer/src/components/analytics/umami.tsx
+++ b/src/renderer/src/components/analytics/umami.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+export const UmamiScriptLoader = () => {
+  // Umami Analytics
+  // Very simple, does not collect or store personal data
+  // Does not log what websites you visit, or anything similar
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return;
+
+    const script = document.createElement('script');
+    script.src = '/umami.js';
+    script.defer = true;
+    script.setAttribute('data-host-url', 'https://umami.iamevan.dev');
+    script.setAttribute('data-website-id', '846df382-cb68-4e59-a97e-76df33a73e90');
+
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return null;
+};

--- a/src/renderer/src/components/analytics/umami.tsx
+++ b/src/renderer/src/components/analytics/umami.tsx
@@ -1,14 +1,15 @@
-
 export const UmamiScriptLoader = () => {
-  if (process.env.NODE_ENV !== 'production') return null;
+  if (process.env.NODE_ENV !== "production") return null;
 
   // Umami Analytics
   // Very simple, does not collect or store personal data
   // Does not log what websites you visit, or anything similar
-  return <script
-    defer
-    src="/umami.js"
-    data-host-url="https://umami.iamevan.dev"
-    data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
-  />
+  return (
+    <script
+      defer
+      src="/umami.js"
+      data-host-url="https://umami.iamevan.dev"
+      data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+    />
+  );
 };

--- a/src/renderer/src/components/analytics/umami.tsx
+++ b/src/renderer/src/components/analytics/umami.tsx
@@ -1,24 +1,14 @@
-import { useEffect } from "react";
 
 export const UmamiScriptLoader = () => {
+  if (process.env.NODE_ENV !== 'production') return null;
+
   // Umami Analytics
   // Very simple, does not collect or store personal data
   // Does not log what websites you visit, or anything similar
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') return;
-
-    const script = document.createElement('script');
-    script.src = '/umami.js';
-    script.defer = true;
-    script.setAttribute('data-host-url', 'https://umami.iamevan.dev');
-    script.setAttribute('data-website-id', '846df382-cb68-4e59-a97e-76df33a73e90');
-
-    document.body.appendChild(script);
-
-    return () => {
-      document.body.removeChild(script);
-    };
-  }, []);
-
-  return null;
+  return <script
+    defer
+    src="/umami.js"
+    data-host-url="https://umami.iamevan.dev"
+    data-website-id="846df382-cb68-4e59-a97e-76df33a73e90"
+  />
 };


### PR DESCRIPTION
Refactor of the Umami analytics integration by:
* extracting the script loader into a separate component
* loading it only when process.env.NODE_ENV === 'production'

(so analytics won't be affected with fake data during development)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Analytics script is now dynamically loaded only in production environments, improving privacy and performance.

- **Refactor**
  - Embedded analytics script and related comments were removed from the HTML and replaced with a dynamic loader component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->