### PR TITLE
fix: drag & drop tabs ordering

### DIFF
--- a/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/space-sidebar.tsx
@@ -107,8 +107,8 @@ export function SpaceSidebar({ space }: { space: Space }) {
         const isTabInGroupA = a.tabs.some((tab) => tab.id === tabId);
         const isTabInGroupB = b.tabs.some((tab) => tab.id === tabId);
 
-        const aIndex = newSortedTabGroups.findIndex((tabGroup) => tabGroup.id === a.id);
-        const bIndex = newSortedTabGroups.findIndex((tabGroup) => tabGroup.id === b.id);
+        const aIndex = sortedTabGroups.findIndex((tabGroup) => tabGroup.id === a.id);
+        const bIndex = sortedTabGroups.findIndex((tabGroup) => tabGroup.id === b.id);
 
         const aPos = isTabInGroupA ? newPosition : aIndex;
         const bPos = isTabInGroupB ? newPosition : bIndex;


### PR DESCRIPTION
This fix addresses a bug where a variable was accessed before it was properly initialized, which resulted in broken tab ordering functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of tab group ordering when moving tabs in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->