### PR TITLE
chore: allow floating sidebar to be attached

### DIFF
--- a/src/renderer/src/components/browser-ui/browser-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/browser-sidebar.tsx
@@ -117,11 +117,11 @@ function SidebarFooterContent() {
 }
 
 // Component for the sidebar header content
-function SidebarHeaderContent({ open, themeClasses }: { open: boolean; themeClasses: string }) {
+function SidebarHeaderContent({ open, themeClasses, variant, setVariant }: { open: boolean; themeClasses: string; variant: SidebarVariant, setVariant: (variant: SidebarVariant) => void }) {
   return (
     <SidebarHeader className={cn(themeClasses, "pb-0 gap-0")}>
       {open && <SidebarWindowControls />}
-      <NavigationControls />
+      <NavigationControls variant={variant} setVariant={setVariant} />
       <SidebarAddressBar />
     </SidebarHeader>
   );
@@ -137,7 +137,8 @@ function SidebarContent({
   handleMouseEnter,
   handleMouseLeave,
   sidebarClassNames,
-  railClassNames
+  railClassNames,
+  setVariant
 }: {
   open: boolean;
   side: SidebarSide;
@@ -148,6 +149,7 @@ function SidebarContent({
   handleMouseLeave: () => void;
   sidebarClassNames: string;
   railClassNames: string;
+  setVariant: (variant: SidebarVariant) => void;
 }) {
   return (
     <Sidebar
@@ -158,7 +160,7 @@ function SidebarContent({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <SidebarHeaderContent open={open} themeClasses={themeClasses} />
+      <SidebarHeaderContent open={open} themeClasses={themeClasses} variant={variant} setVariant={setVariant} />
       <ScrollableSidebarContent />
       <SidebarFooter className={themeClasses}>{open && <SidebarFooterContent />}</SidebarFooter>
       <SidebarRail className={railClassNames} isRightSide={side === "right"} />
@@ -253,6 +255,7 @@ export function BrowserSidebar({ collapseMode, variant, side, setIsHoveringSideb
             handleMouseLeave={handleMouseLeave}
             sidebarClassNames={sidebarClassNames}
             railClassNames={railClassNames}
+            setVariant={setVariant}
           />
         </motion.div>
       )}

--- a/src/renderer/src/components/browser-ui/browser-sidebar.tsx
+++ b/src/renderer/src/components/browser-ui/browser-sidebar.tsx
@@ -117,7 +117,17 @@ function SidebarFooterContent() {
 }
 
 // Component for the sidebar header content
-function SidebarHeaderContent({ open, themeClasses, variant, setVariant }: { open: boolean; themeClasses: string; variant: SidebarVariant, setVariant: (variant: SidebarVariant) => void }) {
+function SidebarHeaderContent({
+  open,
+  themeClasses,
+  variant,
+  setVariant
+}: {
+  open: boolean;
+  themeClasses: string;
+  variant: SidebarVariant;
+  setVariant: (variant: SidebarVariant) => void;
+}) {
   return (
     <SidebarHeader className={cn(themeClasses, "pb-0 gap-0")}>
       {open && <SidebarWindowControls />}

--- a/src/renderer/src/components/browser-ui/sidebar/header/action-buttons.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/header/action-buttons.tsx
@@ -16,6 +16,7 @@ import { SidebarCloseIcon, SidebarOpenIcon, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { ComponentProps, useCallback, useEffect, useRef, useState } from "react";
 import { TabData } from "~/types/tabs";
+import { SidebarVariant } from "../../main";
 
 export type NavigationEntryWithIndex = NavigationEntry & { index: number };
 
@@ -94,7 +95,7 @@ function StopLoadingIcon() {
   );
 }
 
-export function NavigationControls() {
+export function NavigationControls({ variant, setVariant }: { variant: SidebarVariant, setVariant: (variant: SidebarVariant) => void }) {
   const { focusedTab } = useTabs();
   const { open, setOpen } = useSidebar();
 
@@ -124,7 +125,8 @@ export function NavigationControls() {
     });
   }, [focusedTab]);
 
-  if (!open) {
+
+  if (!open && variant === 'sidebar') {
     return (
       <SidebarMenu>
         <div className="mt-3" />
@@ -141,7 +143,11 @@ export function NavigationControls() {
   }
 
   const closeSidebar = () => {
-    setOpen(false);
+    if(variant === 'sidebar') {
+      setOpen(false)
+    } else {
+      setVariant('sidebar')
+    }
   };
 
   const handleStopLoading = () => {
@@ -154,13 +160,15 @@ export function NavigationControls() {
     flow.navigation.reloadTab(focusedTab.id);
   };
 
+  const SidebarIcon = variant === 'floating' && open ? SidebarOpenIcon : SidebarCloseIcon
+
   return (
     <SidebarGroup className="px-1">
       <SidebarMenu className="flex flex-row justify-between">
         {/* Left Side Buttons */}
         <SidebarMenuItem className="flex flex-row gap-0.5">
           <SidebarActionButton
-            icon={<SidebarCloseIcon className="w-4 h-4" />}
+            icon={<SidebarIcon className="w-4 h-4" />}
             onClick={closeSidebar}
             className={SIDEBAR_HOVER_COLOR}
           />

--- a/src/renderer/src/components/browser-ui/sidebar/header/action-buttons.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/header/action-buttons.tsx
@@ -95,7 +95,13 @@ function StopLoadingIcon() {
   );
 }
 
-export function NavigationControls({ variant, setVariant }: { variant: SidebarVariant, setVariant: (variant: SidebarVariant) => void }) {
+export function NavigationControls({
+  variant,
+  setVariant
+}: {
+  variant: SidebarVariant;
+  setVariant: (variant: SidebarVariant) => void;
+}) {
   const { focusedTab } = useTabs();
   const { open, setOpen } = useSidebar();
 
@@ -125,8 +131,7 @@ export function NavigationControls({ variant, setVariant }: { variant: SidebarVa
     });
   }, [focusedTab]);
 
-
-  if (!open && variant === 'sidebar') {
+  if (!open && variant === "sidebar") {
     return (
       <SidebarMenu>
         <div className="mt-3" />
@@ -143,10 +148,10 @@ export function NavigationControls({ variant, setVariant }: { variant: SidebarVa
   }
 
   const closeSidebar = () => {
-    if(variant === 'sidebar') {
-      setOpen(false)
+    if (variant === "sidebar") {
+      setOpen(false);
     } else {
-      setVariant('sidebar')
+      setVariant("sidebar");
     }
   };
 
@@ -160,7 +165,7 @@ export function NavigationControls({ variant, setVariant }: { variant: SidebarVa
     flow.navigation.reloadTab(focusedTab.id);
   };
 
-  const SidebarIcon = variant === 'floating' && open ? SidebarOpenIcon : SidebarCloseIcon
+  const SidebarIcon = variant === "floating" && open ? SidebarOpenIcon : SidebarCloseIcon;
 
   return (
     <SidebarGroup className="px-1">


### PR DESCRIPTION
closes #86

Targets https://github.com/MultiboxLabs/flow-browser/issues/86 with floating sidebar bug impossible to set back to normal sidebar mode without using shortcut keys

EDIT: also I was thinking about adding sth small like `Zustand` to keep thinkgs like `variant` and `setVariant` in small contexts, make them more accessible and prevent props drilling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Sidebar controls now support multiple display variants, allowing users to switch between sidebar modes.
	- Sidebar open/close buttons and icons are now variant-aware, providing a more intuitive navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->