### PR TITLE
Revert "feat: better asleep tabs"

### DIFF
--- a/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
+++ b/src/renderer/src/components/browser-ui/sidebar/content/sidebar-tab-groups.tsx
@@ -99,12 +99,11 @@ export function SidebarTab({ tab, isFocused }: { tab: TabData; isFocused: boolea
         isFocused && "bg-white dark:bg-white/25",
         isFocused && "active:bg-white active:dark:bg-white/25",
         "text-gray-900 dark:text-gray-200",
-        "transition-colors",
-        tab.asleep && "grayscale"
+        "transition-colors"
       )}
       initial={{ opacity: 0, x: -10 }}
       animate={{
-        opacity: tab.asleep ? 0.5 : 1,
+        opacity: 1,
         x: 0,
         scale: isPressed ? 0.985 : 1
       }}


### PR DESCRIPTION
Reverts MultiboxLabs/flow-browser#128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed the grayscale and opacity effects previously applied to tabs marked as "asleep" in the sidebar. All tabs now display with full color and opacity for a consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->