### PR TITLE
Hex Color Input for Theme Settings + Save Button Fix

### DIFF
--- a/src/renderer/src/components/settings/sections/spaces/color-picker.tsx
+++ b/src/renderer/src/components/settings/sections/spaces/color-picker.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect, useCallback } from "react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -13,172 +13,200 @@ interface ColorPickerProps {
   defaultColor: string;
   label: string;
   onChange: (color: string) => void;
+  disabled?: boolean;
+  className?: string;
 }
 
-export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps) {
+export function ColorPicker({
+  defaultColor,
+  label,
+  onChange,
+  disabled = false,
+  className = ""
+}: ColorPickerProps) {
   const colorInputRef = useRef<HTMLInputElement>(null);
   const textInputRef = useRef<HTMLInputElement>(null);
-  const [previewColor, setPreviewColor] = useState(defaultColor || "#ffffff");
-  const [textValue, setTextValue] = useState(defaultColor || "#ffffff");
-  const [isFocused, setIsFocused] = useState(false);
-  const [isEditingText, setIsEditingText] = useState(false);
-  const [validationError, setValidationError] = useState("");
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const colorChangeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Consolidated state
+  const [state, setState] = useState({
+    currentColor: defaultColor || "#ffffff",
+    textValue: defaultColor || "#ffffff",
+    isFocused: false,
+    isEditingText: false,
+    validationError: ""
+  });
 
-  // Sync text value when defaultColor changes (for randomize functionality)
+  // Sync with defaultColor changes
   useEffect(() => {
-    setTextValue(defaultColor || "#ffffff");
-    setPreviewColor(defaultColor || "#ffffff");
+    const newColor = defaultColor || "#ffffff";
+    setState(prev => ({
+      ...prev,
+      currentColor: newColor,
+      textValue: newColor
+    }));
   }, [defaultColor]);
 
-  // Validate hex color format
-  const isValidHexColor = (hex: string): boolean => {
-    const hexRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
-    return hexRegex.test(hex);
-  };
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
-  // Normalize hex color (convert 3-digit to 6-digit)
-  const normalizeHexColor = (hex: string): string => {
+  // Utility functions
+  const isValidHexColor = useCallback((hex: string): boolean => {
+    // More strict hex validation - exactly 3 or 6 characters after #
+    return /^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/.test(hex);
+  }, []);
+
+  const normalizeHexColor = useCallback((hex: string): string => {
     if (hex.length === 4) {
-      // Convert #rgb to #rrggbb
-      return "#" + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
+      return "#" + hex[1].repeat(2) + hex[2].repeat(2) + hex[3].repeat(2);
     }
     return hex;
-  };
+  }, []);
 
-  // Handle color picker change
-  const handleColorPickerChange = () => {
-    if (colorChangeTimeoutRef.current) {
-      clearTimeout(colorChangeTimeoutRef.current);
+  const updateState = useCallback((updates: Partial<typeof state>) => {
+    setState(prev => ({ ...prev, ...updates }));
+  }, []);
+
+  // Debounced onChange call with cleanup
+  const debouncedOnChange = useCallback((color: string) => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
     }
+    timeoutRef.current = setTimeout(() => {
+      onChange(color);
+      timeoutRef.current = null;
+    }, 100);
+  }, [onChange]);
 
-    if (colorInputRef.current) {
-      const newColor = colorInputRef.current.value;
-      setPreviewColor(newColor);
-      setTextValue(newColor);
-      setValidationError("");
+  // Color picker handlers
+  const handleColorPickerChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    if (disabled) return;
 
-      colorChangeTimeoutRef.current = setTimeout(() => {
-        onChange(newColor);
-      }, 100);
+    const newColor = e.target.value;
+    updateState({
+      currentColor: newColor,
+      textValue: newColor,
+      validationError: ""
+    });
+    debouncedOnChange(newColor);
+  }, [updateState, debouncedOnChange, disabled]);
+
+  const handleColorPickerFocus = useCallback(() => {
+    if (!disabled) {
+      updateState({ isFocused: true });
     }
-  };
+  }, [updateState, disabled]);
 
-  // Handle color picker preview update
-  const handleColorPickerPreview = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPreviewColor(e.target.value);
-    setTextValue(e.target.value);
-  };
-
-  // Handle text input change
-  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setTextValue(value);
-
-    // Clear previous validation error
-    setValidationError("");
-
-    // Only validate, don't auto-format while typing
-    let normalizedValue = value;
-    if (value && !value.startsWith("#")) {
-      normalizedValue = "#" + value;
-    }
-
-    // Just validate - don't update the text field or preview while typing
-    if (normalizedValue && isValidHexColor(normalizedValue)) {
-      // Valid color - clear any error but don't update preview until blur/enter
-      setValidationError("");
-    } else if (normalizedValue && normalizedValue !== "#") {
-      setValidationError("Invalid hex color format");
-    }
-  };
-
-  // Handle text input blur (only exit edit mode, don't auto-save)
-  const handleTextBlur = () => {
-    setIsEditingText(false);
-    // Reset to previous valid color when just clicking outside
-    setTextValue(previewColor);
-    setValidationError("");
-  };
-
-  // Apply changes (used by Enter key and Apply button)
-  const applyChanges = () => {
-    if (!textValue || textValue === "#") {
-      setTextValue(previewColor);
-      setValidationError("");
-      setIsEditingText(false);
-      return;
-    }
-
-    // Add # if not present
-    let normalizedValue = textValue;
-    if (textValue && !textValue.startsWith("#")) {
-      normalizedValue = "#" + textValue;
-    }
-
-    if (!isValidHexColor(normalizedValue)) {
-      setValidationError("Invalid hex color format");
-      setTextValue(previewColor); // Reset to last valid color
-    } else {
-      const finalColor = normalizeHexColor(normalizedValue);
-      setPreviewColor(finalColor);
-      setTextValue(finalColor);
-
-      if (colorInputRef.current) {
-        colorInputRef.current.value = finalColor;
-      }
-
-      onChange(finalColor);
-      setValidationError("");
-    }
-    setIsEditingText(false);
-  };
-
-  // Handle text input key press
-  const handleTextKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      applyChanges();
-      textInputRef.current?.blur();
-    } else if (e.key === "Escape") {
-      setTextValue(previewColor);
-      setValidationError("");
-      setIsEditingText(false);
-      textInputRef.current?.blur();
-    }
-  };
-
-  // Handle color picker focus events
-  const handleColorPickerBlur = () => {
-    setIsFocused(false);
+  const handleColorPickerBlur = useCallback(() => {
+    updateState({ isFocused: false });
     if (colorInputRef.current) {
       onChange(colorInputRef.current.value);
     }
-  };
+  }, [updateState, onChange]);
 
-  const handleColorPickerFocus = () => {
-    setIsFocused(true);
-  };
+  // Text input handlers
+  const handleTextChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    if (disabled) return;
 
-  // Toggle edit mode
-  const handleToggleEdit = () => {
-    if (isEditingText) {
-      applyChanges();
+    const value = e.target.value;
+    const normalizedValue = value.startsWith("#") ? value : "#" + value;
+
+    const error = normalizedValue !== "#" && !isValidHexColor(normalizedValue)
+      ? "Invalid hex color format (use #RGB or #RRGGBB)"
+      : "";
+
+    updateState({
+      textValue: value,
+      validationError: error
+    });
+  }, [updateState, isValidHexColor, disabled]);
+
+  // Text editing actions
+  const cancelTextEdit = useCallback(() => {
+    updateState({
+      textValue: state.currentColor,
+      isEditingText: false,
+      validationError: ""
+    });
+  }, [state.currentColor, updateState]);
+
+  const applyTextChanges = useCallback(() => {
+    const { textValue } = state;
+
+    if (!textValue || textValue === "#") {
+      cancelTextEdit();
+      return;
+    }
+
+    const normalizedValue = textValue.startsWith("#") ? textValue : "#" + textValue;
+
+    if (!isValidHexColor(normalizedValue)) {
+      updateState({
+        validationError: "Invalid hex color format (use #RGB or #RRGGBB)",
+        textValue: state.currentColor
+      });
+      return;
+    }
+
+    const finalColor = normalizeHexColor(normalizedValue);
+
+    updateState({
+      currentColor: finalColor,
+      textValue: finalColor,
+      isEditingText: false,
+      validationError: ""
+    });
+
+    if (colorInputRef.current) {
+      colorInputRef.current.value = finalColor;
+    }
+
+    onChange(finalColor);
+  }, [state, updateState, isValidHexColor, normalizeHexColor, onChange, cancelTextEdit]);
+
+  const handleTextKeyPress = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      applyTextChanges();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      cancelTextEdit();
+    }
+  }, [applyTextChanges, cancelTextEdit]);
+
+  const handleTextBlur = useCallback(() => {
+    if (state.isEditingText) {
+      cancelTextEdit();
+    }
+  }, [state.isEditingText, cancelTextEdit]);
+
+  const toggleEditMode = useCallback(() => {
+    if (disabled) return;
+
+    if (state.isEditingText) {
+      applyTextChanges();
     } else {
-      setIsEditingText(true);
-      setTimeout(() => {
+      updateState({ isEditingText: true });
+      // Focus and select text after state update
+      requestAnimationFrame(() => {
         textInputRef.current?.focus();
         textInputRef.current?.select();
-      }, 50);
+      });
     }
-  };
+  }, [state.isEditingText, updateState, applyTextChanges, disabled]);
+
+  // Generate component ID
+  const componentId = `color-picker-${label.toLowerCase().replace(/\s+/g, "-")}`;
 
   return (
-    <div className="space-y-2.5">
-      <Label
-        htmlFor={`color-picker-${label.toLowerCase().replace(/\s+/g, "-")}`}
-        className="text-sm font-medium flex items-center gap-1.5"
-      >
+    <div className={`space-y-2.5 ${className}`.trim()}>
+      <Label htmlFor={componentId} className="text-sm font-medium flex items-center gap-1.5">
         <Palette className="h-3.5 w-3.5 text-muted-foreground" />
         {label}
       </Label>
@@ -188,42 +216,46 @@ export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps)
         <Tooltip>
           <TooltipTrigger asChild>
             <motion.div
-              className="h-10 w-10 rounded-lg shadow-sm flex-shrink-0 relative overflow-hidden cursor-pointer"
-              style={{ backgroundColor: previewColor }}
+              className={`h-10 w-10 rounded-lg shadow-sm flex-shrink-0 relative overflow-hidden cursor-pointer group ${disabled ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+              style={{ backgroundColor: state.currentColor }}
               animate={{
-                scale: isFocused ? 1.05 : 1,
-                boxShadow: isFocused
-                  ? "0 0 0 2px rgba(255,255,255,0.1), 0 0 0 4px " + previewColor + "60"
-                  : "none"
+                scale: state.isFocused && !disabled ? 1.05 : 1,
+                boxShadow: state.isFocused && !disabled
+                  ? `0 0 0 2px rgba(255,255,255,0.1), 0 0 0 4px ${state.currentColor}60`
+                  : "0 1px 3px 0 rgb(0 0 0 / 0.1)"
               }}
               transition={{ duration: 0.2 }}
-              onClick={() => colorInputRef.current?.click()}
+              onClick={() => !disabled && colorInputRef.current?.click()}
             >
               <div
-                className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent"
-                style={{ opacity: isFocused ? 0.2 : 0 }}
+                className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent transition-opacity duration-200"
+                style={{ opacity: state.isFocused && !disabled ? 0.2 : 0 }}
               />
               <div className="absolute inset-0 flex items-center justify-center">
-                <Pipette className="h-4 w-4 text-white/80 opacity-0 group-hover:opacity-100 transition-opacity" />
+                <Pipette className={`h-4 w-4 text-white/80 transition-opacity duration-200 ${disabled ? 'opacity-30' : 'opacity-0 group-hover:opacity-100'
+                  }`} />
               </div>
             </motion.div>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Click to open color picker</p>
+            <p>{disabled ? 'Color picker disabled' : 'Click to open color picker'}</p>
           </TooltipContent>
         </Tooltip>
 
         {/* Hidden Color Input */}
         <input
           ref={colorInputRef}
+          id={componentId}
           type="color"
-          defaultValue={defaultColor || "#ffffff"}
-          onChange={handleColorPickerPreview}
+          value={state.currentColor}
+          onChange={handleColorPickerChange}
           onBlur={handleColorPickerBlur}
           onFocus={handleColorPickerFocus}
-          onInput={handleColorPickerChange}
+          disabled={disabled}
           className="absolute opacity-0 pointer-events-none"
           tabIndex={-1}
+          aria-label={`${label} color picker`}
         />
 
         {/* Text Input Area */}
@@ -231,27 +263,27 @@ export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps)
           <div className="flex items-center gap-2">
             <div className="flex-1">
               <AnimatePresence mode="wait">
-                {isEditingText ? (
+                {state.isEditingText ? (
                   <motion.div
                     key="text-input"
                     initial={{ opacity: 0, y: -2 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -2 }}
                     transition={{ duration: 0.15 }}
-                    className="relative"
                   >
                     <Input
                       ref={textInputRef}
-                      value={textValue}
+                      value={state.textValue}
                       onChange={handleTextChange}
                       onBlur={handleTextBlur}
                       onKeyDown={handleTextKeyPress}
+                      disabled={disabled}
                       placeholder="#FFFFFF"
-                      className={`h-10 font-mono text-sm ${validationError
+                      className={`h-10 font-mono text-sm ${state.validationError
                         ? "border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20"
                         : ""
                         }`}
-                      autoFocus
+                      aria-describedby={state.validationError ? `${componentId}-error` : undefined}
                     />
                   </motion.div>
                 ) : (
@@ -261,18 +293,24 @@ export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps)
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: 2 }}
                     transition={{ duration: 0.15 }}
-                    className="h-10 w-full rounded-lg border bg-background px-3 flex items-center text-sm shadow-xs cursor-pointer overflow-hidden"
-                    onClick={handleToggleEdit}
+                    className={`h-10 w-full rounded-lg border bg-background px-3 flex items-center text-sm shadow-sm overflow-hidden transition-colors ${disabled
+                      ? 'opacity-50 cursor-not-allowed'
+                      : 'cursor-pointer hover:bg-accent/50'
+                      }`}
+                    onClick={toggleEditMode}
                   >
                     <div className="flex items-center justify-between w-full">
-                      <span className="font-mono">{previewColor.toUpperCase()}</span>
+                      <span className="font-mono">{state.currentColor.toUpperCase()}</span>
                       <motion.div
-                        className="flex items-center justify-center h-6 px-2 rounded-md text-xs font-medium bg-muted/50"
-                        whileHover={{ scale: 1.05 }}
-                        whileTap={{ scale: 0.95 }}
+                        className={`flex items-center justify-center h-6 px-2 rounded-md text-xs font-medium transition-colors ${disabled
+                          ? 'bg-muted/30 text-muted-foreground'
+                          : 'bg-muted/50 hover:bg-muted'
+                          }`}
+                        whileHover={disabled ? {} : { scale: 1.05 }}
+                        whileTap={disabled ? {} : { scale: 0.95 }}
                       >
                         <Edit3 className="h-3 w-3 mr-1" />
-                        Edit
+                        {disabled ? 'Disabled' : 'Edit'}
                       </motion.div>
                     </div>
                   </motion.div>
@@ -282,11 +320,11 @@ export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps)
 
             {/* Action Buttons */}
             <AnimatePresence>
-              {isEditingText && (
+              {state.isEditingText && !disabled && (
                 <motion.div
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.9 }}
+                  initial={{ opacity: 0, scale: 0.9, x: 10 }}
+                  animate={{ opacity: 1, scale: 1, x: 0 }}
+                  exit={{ opacity: 0, scale: 0.9, x: 10 }}
                   transition={{ duration: 0.15 }}
                   className="flex gap-1"
                 >
@@ -296,7 +334,8 @@ export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps)
                         variant="outline"
                         size="icon"
                         className="h-10 w-10"
-                        onClick={handleToggleEdit}
+                        onClick={toggleEditMode}
+                        disabled={!!state.validationError}
                       >
                         <Check className="h-4 w-4" />
                       </Button>
@@ -312,11 +351,7 @@ export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps)
                         variant="outline"
                         size="icon"
                         className="h-10 w-10"
-                        onClick={() => {
-                          setTextValue(previewColor);
-                          setValidationError("");
-                          setIsEditingText(false);
-                        }}
+                        onClick={cancelTextEdit}
                       >
                         <X className="h-4 w-4" />
                       </Button>
@@ -332,16 +367,18 @@ export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps)
 
           {/* Validation Error */}
           <AnimatePresence>
-            {validationError && (
+            {state.validationError && (
               <motion.p
+                id={`${componentId}-error`}
                 initial={{ opacity: 0, y: -5 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -5 }}
                 transition={{ duration: 0.2 }}
                 className="text-xs text-destructive flex items-center gap-1"
+                role="alert"
               >
                 <X className="h-3 w-3" />
-                {validationError}
+                {state.validationError}
               </motion.p>
             )}
           </AnimatePresence>

--- a/src/renderer/src/components/settings/sections/spaces/color-picker.tsx
+++ b/src/renderer/src/components/settings/sections/spaces/color-picker.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useCallback } from "react";
+import { useRef, useState, useEffect, useCallback, useId } from "react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -201,8 +201,8 @@ export function ColorPicker({
     }
   }, [state.isEditingText, updateState, applyTextChanges, disabled]);
 
-  // Generate component ID
-  const componentId = `color-picker-${label.toLowerCase().replace(/\s+/g, "-")}`;
+  // Generate unique component ID
+  const componentId = useId();
 
   return (
     <div className={`space-y-2.5 ${className}`.trim()}>

--- a/src/renderer/src/components/settings/sections/spaces/color-picker.tsx
+++ b/src/renderer/src/components/settings/sections/spaces/color-picker.tsx
@@ -1,7 +1,10 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { Label } from "@/components/ui/label";
-import { motion } from "motion/react";
-import { Palette } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { motion, AnimatePresence } from "motion/react";
+import { Palette, Edit3, Check, X, Pipette } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 // ==============================
 // ColorPicker Component
@@ -13,59 +16,157 @@ interface ColorPickerProps {
 }
 
 export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const colorInputRef = useRef<HTMLInputElement>(null);
+  const textInputRef = useRef<HTMLInputElement>(null);
   const [previewColor, setPreviewColor] = useState(defaultColor || "#ffffff");
+  const [textValue, setTextValue] = useState(defaultColor || "#ffffff");
   const [isFocused, setIsFocused] = useState(false);
+  const [isEditingText, setIsEditingText] = useState(false);
+  const [validationError, setValidationError] = useState("");
 
   const colorChangeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Handle color change without re-rendering on every input
-  const handleColorChange = () => {
+  // Sync text value when defaultColor changes (for randomize functionality)
+  useEffect(() => {
+    setTextValue(defaultColor || "#ffffff");
+    setPreviewColor(defaultColor || "#ffffff");
+  }, [defaultColor]);
+
+  // Validate hex color format
+  const isValidHexColor = (hex: string): boolean => {
+    const hexRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
+    return hexRegex.test(hex);
+  };
+
+  // Normalize hex color (convert 3-digit to 6-digit)
+  const normalizeHexColor = (hex: string): string => {
+    if (hex.length === 4) {
+      // Convert #rgb to #rrggbb
+      return "#" + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
+    }
+    return hex;
+  };
+
+  // Handle color picker change
+  const handleColorPickerChange = () => {
     if (colorChangeTimeoutRef.current) {
       clearTimeout(colorChangeTimeoutRef.current);
     }
 
-    if (inputRef.current) {
-      const newColor = inputRef.current.value;
+    if (colorInputRef.current) {
+      const newColor = colorInputRef.current.value;
+      setPreviewColor(newColor);
+      setTextValue(newColor);
+      setValidationError("");
 
       colorChangeTimeoutRef.current = setTimeout(() => {
-        setPreviewColor(newColor);
         onChange(newColor);
       }, 100);
     }
   };
 
-  // Update preview color without triggering re-renders in parent
-  const handlePreviewUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
+  // Handle color picker preview update
+  const handleColorPickerPreview = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPreviewColor(e.target.value);
+    setTextValue(e.target.value);
   };
 
-  // Only call onChange when focus is lost (user is done selecting)
-  const handleBlur = () => {
-    setIsFocused(false);
-    if (inputRef.current) {
-      onChange(inputRef.current.value);
+  // Handle text input change
+  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setTextValue(value);
+
+    // Clear previous validation error
+    setValidationError("");
+
+    // Add # if not present and value is not empty
+    let normalizedValue = value;
+    if (value && !value.startsWith("#")) {
+      normalizedValue = "#" + value;
+      setTextValue(normalizedValue);
+    }
+
+    // Validate and update if valid
+    if (normalizedValue && isValidHexColor(normalizedValue)) {
+      const finalColor = normalizeHexColor(normalizedValue);
+      setPreviewColor(finalColor);
+      setTextValue(finalColor);
+
+      // Update color picker input
+      if (colorInputRef.current) {
+        colorInputRef.current.value = finalColor;
+      }
+
+      onChange(finalColor);
+    } else if (normalizedValue && normalizedValue !== "#") {
+      setValidationError("Invalid hex color format");
     }
   };
 
-  const handleFocus = () => {
+  // Handle text input blur
+  const handleTextBlur = () => {
+    setIsEditingText(false);
+
+    if (!textValue || textValue === "#") {
+      setTextValue(previewColor);
+      setValidationError("");
+      return;
+    }
+
+    if (!isValidHexColor(textValue)) {
+      setValidationError("Invalid hex color format");
+      setTextValue(previewColor); // Reset to last valid color
+    } else {
+      const finalColor = normalizeHexColor(textValue);
+      setPreviewColor(finalColor);
+      setTextValue(finalColor);
+
+      if (colorInputRef.current) {
+        colorInputRef.current.value = finalColor;
+      }
+
+      onChange(finalColor);
+      setValidationError("");
+    }
+  };
+
+  // Handle text input key press
+  const handleTextKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleTextBlur();
+      textInputRef.current?.blur();
+    } else if (e.key === "Escape") {
+      setTextValue(previewColor);
+      setValidationError("");
+      setIsEditingText(false);
+      textInputRef.current?.blur();
+    }
+  };
+
+  // Handle color picker focus events
+  const handleColorPickerBlur = () => {
+    setIsFocused(false);
+    if (colorInputRef.current) {
+      onChange(colorInputRef.current.value);
+    }
+  };
+
+  const handleColorPickerFocus = () => {
     setIsFocused(true);
   };
 
-  // Get contrasting text color for the preview
-  const getContrastingTextColor = (hexColor: string) => {
-    // Convert hex to RGB
-    const r = parseInt(hexColor.slice(1, 3), 16);
-    const g = parseInt(hexColor.slice(3, 5), 16);
-    const b = parseInt(hexColor.slice(5, 7), 16);
-
-    // Calculate luminance
-    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-
-    return luminance > 0.5 ? "#000000" : "#ffffff";
+  // Toggle edit mode
+  const handleToggleEdit = () => {
+    if (isEditingText) {
+      handleTextBlur();
+    } else {
+      setIsEditingText(true);
+      setTimeout(() => {
+        textInputRef.current?.focus();
+        textInputRef.current?.select();
+      }, 50);
+    }
   };
-
-  const textColor = getContrastingTextColor(previewColor);
 
   return (
     <div className="space-y-2.5">
@@ -76,55 +177,169 @@ export function ColorPicker({ defaultColor, label, onChange }: ColorPickerProps)
         <Palette className="h-3.5 w-3.5 text-muted-foreground" />
         {label}
       </Label>
-      <div className="flex items-center gap-3">
-        <motion.div
-          className="h-10 w-10 rounded-lg shadow-sm flex-shrink-0 relative overflow-hidden"
-          style={{ backgroundColor: previewColor }}
-          animate={{
-            scale: isFocused ? 1.05 : 1,
-            boxShadow: isFocused ? "0 0 0 2px rgba(255,255,255,0.1), 0 0 0 4px " + previewColor + "60" : "none"
-          }}
-          transition={{ duration: 0.2 }}
-        >
-          <div
-            className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent"
-            style={{ opacity: isFocused ? 0.2 : 0 }}
-          />
-        </motion.div>
-        <div className="relative w-full">
-          <input
-            id={`color-picker-${label.toLowerCase().replace(/\s+/g, "-")}`}
-            ref={inputRef}
-            type="color"
-            defaultValue={defaultColor || "#ffffff"}
-            onChange={handlePreviewUpdate}
-            onBlur={handleBlur}
-            onFocus={handleFocus}
-            onInput={handleColorChange}
-            className="h-10 w-full rounded-lg border cursor-pointer absolute inset-0 opacity-0 z-10"
-          />
-          <motion.div
-            className="h-10 w-full rounded-lg border bg-background px-3 flex items-center text-sm shadow-xs cursor-pointer overflow-hidden"
-            animate={{
-              borderColor: isFocused ? previewColor : "rgb(var(--border))",
-              borderWidth: isFocused ? "1.5px" : "1px"
-            }}
-            transition={{ duration: 0.2 }}
-          >
-            <div className="flex items-center justify-between w-full">
-              <span>{previewColor.toUpperCase()}</span>
-              <motion.div
-                className="flex items-center justify-center h-6 px-2 rounded-md text-xs font-medium"
-                animate={{
-                  backgroundColor: isFocused ? previewColor : "transparent",
-                  color: isFocused ? textColor : "inherit"
-                }}
-                transition={{ duration: 0.2 }}
-              >
-                {isFocused ? "Selecting" : "Change"}
-              </motion.div>
+
+      <div className="flex items-start gap-3">
+        {/* Color Preview Circle */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <motion.div
+              className="h-10 w-10 rounded-lg shadow-sm flex-shrink-0 relative overflow-hidden cursor-pointer"
+              style={{ backgroundColor: previewColor }}
+              animate={{
+                scale: isFocused ? 1.05 : 1,
+                boxShadow: isFocused
+                  ? "0 0 0 2px rgba(255,255,255,0.1), 0 0 0 4px " + previewColor + "60"
+                  : "none"
+              }}
+              transition={{ duration: 0.2 }}
+              onClick={() => colorInputRef.current?.click()}
+            >
+              <div
+                className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent"
+                style={{ opacity: isFocused ? 0.2 : 0 }}
+              />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Pipette className="h-4 w-4 text-white/80 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </div>
+            </motion.div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Click to open color picker</p>
+          </TooltipContent>
+        </Tooltip>
+
+        {/* Hidden Color Input */}
+        <input
+          ref={colorInputRef}
+          type="color"
+          defaultValue={defaultColor || "#ffffff"}
+          onChange={handleColorPickerPreview}
+          onBlur={handleColorPickerBlur}
+          onFocus={handleColorPickerFocus}
+          onInput={handleColorPickerChange}
+          className="absolute opacity-0 pointer-events-none"
+          tabIndex={-1}
+        />
+
+        {/* Text Input Area */}
+        <div className="flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <div className="flex-1">
+              <AnimatePresence mode="wait">
+                {isEditingText ? (
+                  <motion.div
+                    key="text-input"
+                    initial={{ opacity: 0, y: -2 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -2 }}
+                    transition={{ duration: 0.15 }}
+                    className="relative"
+                  >
+                    <Input
+                      ref={textInputRef}
+                      value={textValue}
+                      onChange={handleTextChange}
+                      onBlur={handleTextBlur}
+                      onKeyDown={handleTextKeyPress}
+                      placeholder="#FFFFFF"
+                      className={`h-10 font-mono text-sm ${validationError
+                        ? "border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20"
+                        : ""
+                        }`}
+                      autoFocus
+                    />
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="display-mode"
+                    initial={{ opacity: 0, y: 2 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 2 }}
+                    transition={{ duration: 0.15 }}
+                    className="h-10 w-full rounded-lg border bg-background px-3 flex items-center text-sm shadow-xs cursor-pointer overflow-hidden"
+                    onClick={handleToggleEdit}
+                  >
+                    <div className="flex items-center justify-between w-full">
+                      <span className="font-mono">{previewColor.toUpperCase()}</span>
+                      <motion.div
+                        className="flex items-center justify-center h-6 px-2 rounded-md text-xs font-medium bg-muted/50"
+                        whileHover={{ scale: 1.05 }}
+                        whileTap={{ scale: 0.95 }}
+                      >
+                        <Edit3 className="h-3 w-3 mr-1" />
+                        Edit
+                      </motion.div>
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
-          </motion.div>
+
+            {/* Action Buttons */}
+            <AnimatePresence>
+              {isEditingText && (
+                <motion.div
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.9 }}
+                  transition={{ duration: 0.15 }}
+                  className="flex gap-1"
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-10 w-10"
+                        onClick={handleToggleEdit}
+                      >
+                        <Check className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Apply color</p>
+                    </TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-10 w-10"
+                        onClick={() => {
+                          setTextValue(previewColor);
+                          setValidationError("");
+                          setIsEditingText(false);
+                        }}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Cancel</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+
+          {/* Validation Error */}
+          <AnimatePresence>
+            {validationError && (
+              <motion.p
+                initial={{ opacity: 0, y: -5 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -5 }}
+                transition={{ duration: 0.2 }}
+                className="text-xs text-destructive flex items-center gap-1"
+              >
+                <X className="h-3 w-3" />
+                {validationError}
+              </motion.p>
+            )}
+          </AnimatePresence>
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
+++ b/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
@@ -38,7 +38,7 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
       editedSpace.bgEndColor !== currentSpace.bgEndColor ||
       editedSpace.icon !== currentSpace.icon
     );
-  }, [editedSpace.name, editedSpace.bgStartColor, editedSpace.bgEndColor, editedSpace.icon, currentSpace.name, currentSpace.bgStartColor, currentSpace.bgEndColor, currentSpace.icon]);
+  }, [editedSpace, currentSpace]);
 
   // Reset save success state when changes are detected
   useEffect(() => {

--- a/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
+++ b/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, Loader2, Save, Settings, Trash2, PaintBucket, Check } from "lucide-react";
 import type { Space } from "~/flow/interfaces/sessions/spaces";
@@ -31,30 +31,21 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
   };
 
   // Detect if there are unsaved changes
-  const hasChanges = () => {
+  const hasChanges = useCallback(() => {
     return (
       editedSpace.name !== currentSpace.name ||
       editedSpace.bgStartColor !== currentSpace.bgStartColor ||
       editedSpace.bgEndColor !== currentSpace.bgEndColor ||
       editedSpace.icon !== currentSpace.icon
     );
-  };
+  }, [editedSpace.name, editedSpace.bgStartColor, editedSpace.bgEndColor, editedSpace.icon, currentSpace.name, currentSpace.bgStartColor, currentSpace.bgEndColor, currentSpace.icon]);
 
   // Reset save success state when changes are detected
   useEffect(() => {
-    if (saveSuccess) {
-      const currentHasChanges = (
-        editedSpace.name !== currentSpace.name ||
-        editedSpace.bgStartColor !== currentSpace.bgStartColor ||
-        editedSpace.bgEndColor !== currentSpace.bgEndColor ||
-        editedSpace.icon !== currentSpace.icon
-      );
-
-      if (currentHasChanges) {
-        setSaveSuccess(false);
-      }
+    if (saveSuccess && hasChanges()) {
+      setSaveSuccess(false);
     }
-  }, [editedSpace.name, editedSpace.bgStartColor, editedSpace.bgEndColor, editedSpace.icon, saveSuccess, currentSpace.name, currentSpace.bgStartColor, currentSpace.bgEndColor, currentSpace.icon]);
+  }, [hasChanges, saveSuccess]);
 
   // Handle space update
   const handleSave = async () => {

--- a/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
+++ b/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, Loader2, Save, Settings, Trash2, PaintBucket, Check } from "lucide-react";
 import type { Space } from "~/flow/interfaces/sessions/spaces";
@@ -18,6 +18,7 @@ interface SpaceEditorProps {
 export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceEditorProps) {
   // State management
   const [editedSpace, setEditedSpace] = useState<Space>({ ...space });
+  const [currentSpace, setCurrentSpace] = useState<Space>({ ...space }); // Track the current saved state
   const [activeTab, setActiveTab] = useState("basic");
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -29,6 +30,32 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
     setEditedSpace((prev) => ({ ...prev, ...updates }));
   };
 
+  // Detect if there are unsaved changes
+  const hasChanges = () => {
+    return (
+      editedSpace.name !== currentSpace.name ||
+      editedSpace.bgStartColor !== currentSpace.bgStartColor ||
+      editedSpace.bgEndColor !== currentSpace.bgEndColor ||
+      editedSpace.icon !== currentSpace.icon
+    );
+  };
+
+  // Reset save success state when changes are detected
+  useEffect(() => {
+    if (saveSuccess) {
+      const currentHasChanges = (
+        editedSpace.name !== currentSpace.name ||
+        editedSpace.bgStartColor !== currentSpace.bgStartColor ||
+        editedSpace.bgEndColor !== currentSpace.bgEndColor ||
+        editedSpace.icon !== currentSpace.icon
+      );
+
+      if (currentHasChanges) {
+        setSaveSuccess(false);
+      }
+    }
+  }, [editedSpace.name, editedSpace.bgStartColor, editedSpace.bgEndColor, editedSpace.icon, saveSuccess, currentSpace.name, currentSpace.bgStartColor, currentSpace.bgEndColor, currentSpace.icon]);
+
   // Handle space update
   const handleSave = async () => {
     setIsSaving(true);
@@ -37,19 +64,19 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
       // Only send the fields that have changed
       const updatedFields: Partial<Space> = {};
 
-      if (editedSpace.name !== space.name) {
+      if (editedSpace.name !== currentSpace.name) {
         updatedFields.name = editedSpace.name;
       }
 
-      if (editedSpace.bgStartColor !== space.bgStartColor) {
+      if (editedSpace.bgStartColor !== currentSpace.bgStartColor) {
         updatedFields.bgStartColor = editedSpace.bgStartColor;
       }
 
-      if (editedSpace.bgEndColor !== space.bgEndColor) {
+      if (editedSpace.bgEndColor !== currentSpace.bgEndColor) {
         updatedFields.bgEndColor = editedSpace.bgEndColor;
       }
 
-      if (editedSpace.icon !== space.icon) {
+      if (editedSpace.icon !== currentSpace.icon) {
         updatedFields.icon = editedSpace.icon;
       }
 
@@ -58,14 +85,10 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
 
         await flow.spaces.updateSpace(space.profileId, space.id, updatedFields);
         onSpacesUpdate(); // Refetch spaces after successful update
-        setSaveSuccess(true);
 
-        // Auto-close after short delay
-        setTimeout(() => {
-          if (saveSuccess) {
-            onClose();
-          }
-        }, 1500);
+        // Update current space state with the saved values
+        setCurrentSpace({ ...editedSpace });
+        setSaveSuccess(true);
       } else {
         // No changes to save
         onClose();
@@ -97,16 +120,6 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
       ...editedSpace,
       name: e.target.value
     });
-  };
-
-  // Detect if there are unsaved changes
-  const hasChanges = () => {
-    return (
-      editedSpace.name !== space.name ||
-      editedSpace.bgStartColor !== space.bgStartColor ||
-      editedSpace.bgEndColor !== space.bgEndColor ||
-      editedSpace.icon !== space.icon
-    );
   };
 
   return (


### PR DESCRIPTION
## What’s Changed

- Added support for pasting hex color codes directly into the theme color fields (start and end) without opening the color picker.
<img width="634" height="287" alt="image" src="https://github.com/user-attachments/assets/8bcd1617-49c2-482d-82ed-d6ef490cb9c8" />
<img width="311" height="97" alt="image" src="https://github.com/user-attachments/assets/a9479b7b-0e16-4105-90f4-1a12e9e2aa93" />

We are still able to open the color picker by clicking the color box.
<img width="378" height="115" alt="image" src="https://github.com/user-attachments/assets/4f91e93b-86c3-404b-a643-b94b65a4e575" />
<img width="313" height="421" alt="image" src="https://github.com/user-attachments/assets/d90c842c-d2d2-4c44-b729-20ec417e15e4" />


- Fixed bug where the "Save" button stays in "Saved" state after making additional changes. It now resets properly so you can save again without leaving the page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced color picker with both visual and hex code text input, including live validation, editing controls, and improved user feedback.
  * Color input now supports error messages, animated transitions, disabled state, and better accessibility.

* **Improvements**
  * Space editor now more accurately tracks unsaved changes and save status, ensuring the interface reflects the current state after edits or saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->