### PR TITLE
feat: global media controls in sidebar

### DIFF
--- a/design/GLOBAL_MEDIA_CONTROLS.md
+++ b/design/GLOBAL_MEDIA_CONTROLS.md
@@ -361,16 +361,28 @@ The current IPC model sends tab data per-window. Each window's sidebar shows med
 
 ## Implementation Order
 
-| Step | Phase   | Effort | Description                                                        |
-| ---- | ------- | ------ | ------------------------------------------------------------------ |
-| 1    | 1.4     | Small  | Add mute/unmute to tab context menu                                |
-| 2    | 1.1     | Medium | Add media play/pause/skip IPC handlers (executeJavaScript)         |
-| 3    | 1.2-1.3 | Small  | Extend FlowTabsAPI interface + preload bridge                      |
-| 4    | 1.5     | Medium | Build GlobalMediaControls sidebar component (title + favicon only) |
-| 5    | 2.1-2.2 | Large  | Add MediaSession metadata extraction in main process               |
-| 6    | 2.3-2.4 | Medium | Extend TabData + enhance UI with track/artist/artwork              |
-| 7    | 3.1-3.3 | Small  | Register hardware media key shortcuts                              |
-| 8    | 4       | Small  | Polish: multi-tab, animations, edge cases                          |
+| Step | Phase   | Effort | Status    | Description                                                        |
+| ---- | ------- | ------ | --------- | ------------------------------------------------------------------ |
+| 1    | 1.4     | Small  | DONE      | Add mute/unmute to tab context menu                                |
+| 2    | 1.1     | Medium | DONE      | Add media play/pause/skip IPC handlers (executeJavaScript)         |
+| 3    | 1.2-1.3 | Small  | DONE      | Extend FlowTabsAPI interface + preload bridge                      |
+| 4    | 1.5     | Medium | DONE      | Build GlobalMediaControls sidebar component (title + favicon only) |
+| 5    | 2.1-2.2 | Large  | DONE      | Add MediaSession metadata extraction via preload push approach     |
+| 6    | 2.3-2.4 | Medium | DONE      | Extend TabData + enhance UI with track/artist/artwork              |
+| 7    | 3.1-3.3 | Small  | CANCELLED | Hardware media keys (handled natively by Chromium/system)          |
+| 8    | 4       | Small  | DONE      | Multi-tab cards, active tab filtering, animations                  |
+
+### Implementation Notes
+
+**Preload-based push approach (Phase 2)**: Instead of polling via `executeJavaScript`, we use `contextBridge.executeInMainWorld()` to inject a MutationObserver + play/pause event listeners that push metadata changes via IPC. This is more efficient and avoids the complexity of managing polling intervals from the main process.
+
+**Action handler monkey-patching**: The preload also monkey-patches `navigator.mediaSession.setActionHandler()` to capture handler references in `window.__flowMediaActionHandlers`. This allows skip track and play/pause controls to call the page's actual MediaSession handlers directly, rather than dispatching fake keyboard events which don't trigger MediaSession handlers.
+
+**Background tab compatibility**: Uses `setTimeout` (not `requestAnimationFrame`) for debouncing because Chromium completely suspends rAF in background tabs. Play/pause events are sent immediately (not debounced) for instant UI response.
+
+**Playback state derivation**: Always derives playback state from the actual `<video>`/`<audio>` element's `.paused` property as ground truth, falling back to `navigator.mediaSession.playbackState` only when no media element exists. Many sites set playbackState to "playing" but never update it to "paused".
+
+**TODO**: Support media controls in iframes (e.g. YouTube embeds). Currently only watches the main frame to avoid duplicate/conflicting messages.
 
 ---
 

--- a/design/GLOBAL_MEDIA_CONTROLS.md
+++ b/design/GLOBAL_MEDIA_CONTROLS.md
@@ -1,0 +1,389 @@
+# Global Media Controls
+
+## Overview
+
+Add browser-level media controls to the sidebar UI so users can see what's playing, play/pause, skip tracks, and mute tabs without switching to them.
+
+## Current State (What Already Exists)
+
+### Media State Tracking
+
+The `Tab` class (`src/main/controllers/tabs-controller/tab.ts:160-161`) already tracks two media-related properties:
+
+- `audible: boolean` -- whether the tab is currently producing audio (from `webContents.isCurrentlyAudible()`)
+- `muted: boolean` -- whether the tab's audio is muted (from `webContents.isAudioMuted()`)
+
+These are updated via coalesced `audio-state-changed`, `media-started-playing`, and `media-paused` WebContents events (`tab.ts:461-472`).
+
+### Mute/Unmute
+
+Full round-trip is implemented:
+
+- **Main**: `tabs:set-tab-muted` IPC handler (`src/main/ipc/browser/tabs.ts:302-311`) calls `webContents.setAudioMuted()`
+- **Preload**: `flow.tabs.setTabMuted(tabId, muted)` (`src/preload/index.ts:467-468`)
+- **Renderer**: Per-tab audio indicator with animated Volume2/VolumeX icons in the sidebar (`src/renderer/src/components/browser-ui/browser-sidebar/_components/tab-group.tsx:127-145`)
+
+### IPC Update Channel
+
+Tab content changes (title, url, audible, muted, isLoading, etc.) are debounced at 80ms and sent via `tabs:on-tabs-content-updated` as lightweight per-tab patches (`src/main/ipc/browser/tabs.ts:192-209`). This means the renderer already receives near-real-time `audible`/`muted` state for all tabs.
+
+### Picture-in-Picture
+
+Auto-PiP for tabs with playing video when they become hidden (`src/main/controllers/tabs-controller/tab-lifecycle.ts:245-291`). Uses `webContents.executeJavaScript()` to interact with page media elements.
+
+### What's Missing
+
+1. No MediaSession metadata forwarding (track title, artist, album art)
+2. No media playback controls (play/pause/skip without switching tabs)
+3. No global "now playing" UI beyond per-tab speaker icons
+4. No hardware media key support
+5. No mute/unmute in tab context menu
+
+---
+
+## Architecture
+
+### Data Flow
+
+```
+Web Page (navigator.mediaSession)
+  --> Content Script (injected JS)
+    --> Tab class (main process) -- stores media metadata + playback state
+      --> IPC content update channel (80ms debounce, existing)
+        --> TabsProvider (renderer) -- existing tab data includes new fields
+          --> GlobalMediaControls component (renderer) -- derives "now playing" from tab data
+```
+
+### Design Principles
+
+1. **Piggyback on existing infrastructure** -- Media metadata is added to the `Tab` class and flows through the same debounced IPC update channel already used for title/url/audible/muted. No new IPC channels for state.
+2. **Controls via `executeJavaScript`** -- Play/pause/skip are executed on the tab's webContents via JS injection, same pattern as PiP. No new content script IPC needed for actions.
+3. **Renderer derives, doesn't own** -- The renderer derives "which tab is the primary media tab" from existing `TabsProvider` data. No separate media state store.
+4. **Progressive enhancement** -- Phase 1 works with just `audible`/`muted` + tab title (no MediaSession). Phase 2 adds rich metadata.
+
+---
+
+## Phase 1: Basic Media Controls (audible/muted only)
+
+Uses only the data already available in `TabData` (`audible`, `muted`, `title`, `faviconURL`). No main process changes needed for state -- only for playback control actions.
+
+### 1.1 Add Media Control IPC Handlers
+
+**File: `src/main/ipc/browser/tabs.ts`**
+
+Add handlers that execute JS on a tab's webContents to control playback:
+
+```typescript
+ipcMain.handle("tabs:media-play-pause", async (_event, tabId: number) => {
+  const tab = tabsController.getTabById(tabId);
+  if (!tab?.webContents) return false;
+
+  // Try MediaSession first, fall back to finding media elements
+  const script = `
+    (function() {
+      // Try toggling via media elements directly
+      const media = document.querySelector('video, audio');
+      if (media) {
+        if (media.paused) { media.play(); } else { media.pause(); }
+        return true;
+      }
+      return false;
+    })()
+  `;
+  try {
+    return await tab.webContents.executeJavaScript(script, true);
+  } catch { return false; }
+});
+
+ipcMain.handle("tabs:media-next-track", async (_event, tabId: number) => { ... });
+ipcMain.handle("tabs:media-previous-track", async (_event, tabId: number) => { ... });
+```
+
+### 1.2 Extend Shared Types
+
+**File: `src/shared/flow/interfaces/browser/tabs.ts`**
+
+Add to `FlowTabsAPI`:
+
+```typescript
+mediaPlayPause: (tabId: number) => Promise<boolean>;
+mediaNextTrack: (tabId: number) => Promise<boolean>;
+mediaPreviousTrack: (tabId: number) => Promise<boolean>;
+```
+
+### 1.3 Extend Preload Bridge
+
+**File: `src/preload/index.ts`**
+
+Add to the `tabsAPI` object:
+
+```typescript
+mediaPlayPause: async (tabId: number) => ipcRenderer.invoke("tabs:media-play-pause", tabId),
+mediaNextTrack: async (tabId: number) => ipcRenderer.invoke("tabs:media-next-track", tabId),
+mediaPreviousTrack: async (tabId: number) => ipcRenderer.invoke("tabs:media-previous-track", tabId),
+```
+
+### 1.4 Add Mute/Unmute to Tab Context Menu
+
+**File: `src/main/ipc/browser/tabs.ts`** (in `tabs:show-context-menu` handler)
+
+Add a menu item after the separator, before "Close Tab":
+
+```typescript
+contextMenu.append(
+  new MenuItem({
+    label: tab.muted ? "Unmute Tab" : "Mute Tab",
+    click: () => {
+      tab.webContents?.setAudioMuted(!tab.muted);
+      tab.updateTabState();
+    }
+  })
+);
+```
+
+### 1.5 GlobalMediaControls Renderer Component
+
+**File: `src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx`**
+
+A compact bar in the sidebar that appears when any tab is playing audio.
+
+```
++------------------------------------------+
+|  [favicon] Tab Title           [>] [x]   |
++------------------------------------------+
+```
+
+- **Derives media tabs** from `TabsProvider`: filters all tabs where `audible === true || muted === true` (muted tabs were playing before mute)
+- **Primary media tab**: the first audible tab, or if none are audible, the first muted tab
+- **Shows**: favicon, tab title (truncated), play/pause toggle, mute toggle
+- **Click on title/favicon**: switches to that tab via `flow.tabs.switchToTab()`
+- **AnimatePresence** for show/hide (consistent with existing patterns in the codebase)
+
+**Placement in `src/renderer/src/components/browser-ui/browser-sidebar/inner.tsx`**:
+
+Between `<UpdateBanner />` and the bottom settings row (line 67-69):
+
+```tsx
+{/* Update Banner */}
+<UpdateBanner />
+{/* Global Media Controls */}
+<GlobalMediaControls />
+{/* Bottom Section */}
+<div className="shrink-0 flex items-center ...">
+```
+
+---
+
+## Phase 2: MediaSession Metadata
+
+Adds rich metadata from `navigator.mediaSession` (track title, artist, album art).
+
+### 2.1 Extend Tab Class with Media Metadata
+
+**File: `src/main/controllers/tabs-controller/tab.ts`**
+
+Add new content properties:
+
+```typescript
+// Media metadata (from page's navigator.mediaSession)
+public mediaTitle: string | null = null;
+public mediaArtist: string | null = null;
+public mediaArtwork: string | null = null;
+public mediaPlaybackState: "playing" | "paused" | "none" = "none";
+```
+
+Add `"mediaTitle" | "mediaArtist" | "mediaArtwork" | "mediaPlaybackState"` to `TabContentProperty`.
+
+### 2.2 Inject MediaSession Observer
+
+**File: `src/main/controllers/tabs-controller/tab.ts`** (in `setupWebContentsListeners`)
+
+After the page loads, inject a script that polls `navigator.mediaSession` and sends metadata back:
+
+```typescript
+webContents.on("did-finish-load", () => {
+  webContents.executeJavaScript(`
+    (function() {
+      if (window.__flowMediaObserver) return;
+      window.__flowMediaObserver = true;
+
+      const send = () => {
+        const ms = navigator.mediaSession;
+        if (!ms || !ms.metadata) return;
+        // Post to main process via a custom DOM event that the
+        // preload script listens for, or use a polling approach
+        // that the main process reads via executeJavaScript.
+      };
+
+      // Poll every 2 seconds (MediaSession has no change event)
+      setInterval(send, 2000);
+    })()
+  `);
+});
+```
+
+**Alternative (preferred)**: Instead of polling from injected JS, poll from the main process on tabs that are `audible === true`. This avoids injecting persistent scripts into web pages:
+
+```typescript
+// In TabsController or a new MediaMetadataManager
+// When a tab becomes audible, start polling its metadata every 2s
+// When it stops being audible, stop polling
+const script = `
+  (function() {
+    const ms = navigator.mediaSession;
+    if (!ms?.metadata) return null;
+    return {
+      title: ms.metadata.title || null,
+      artist: ms.metadata.artist || null,
+      artwork: (ms.metadata.artwork?.[0]?.src) || null,
+      playbackState: ms.playbackState || "none"
+    };
+  })()
+`;
+```
+
+### 2.3 Extend `TabData` Shared Type
+
+**File: `src/shared/types/tabs.ts`**
+
+Add to `TabData`:
+
+```typescript
+export type TabData = Omit<PersistedTabData, "navHistory" | "navHistoryIndex"> & {
+  // ... existing fields ...
+  mediaTitle: string | null;
+  mediaArtist: string | null;
+  mediaArtwork: string | null;
+  mediaPlaybackState: "playing" | "paused" | "none";
+};
+```
+
+These are runtime-only (NOT added to `PersistedTabData`).
+
+### 2.4 Enhance GlobalMediaControls UI
+
+Update the component to display rich metadata when available:
+
+```
++------------------------------------------+
+|  [artwork]  Track Title                  |
+|             Artist Name     [<<][>][>>]  |
++------------------------------------------+
+```
+
+- Falls back to favicon + tab title when MediaSession metadata is unavailable
+- Show next/prev buttons only when the page's MediaSession declares those action handlers (this can be detected by attempting the action and checking the result, or by querying `navigator.mediaSession` capabilities)
+
+---
+
+## Phase 3: Hardware Media Keys
+
+### 3.1 Register Global Shortcuts
+
+**File: `src/main/modules/shortcuts.ts`** (or new file `src/main/modules/media-keys.ts`)
+
+```typescript
+import { globalShortcut } from "electron";
+
+export function registerMediaKeys(getMediaTab: () => Tab | null) {
+  globalShortcut.register("MediaPlayPause", () => {
+    const tab = getMediaTab();
+    if (tab?.webContents) {
+      tab.webContents.executeJavaScript(`...play/pause script...`);
+    }
+  });
+
+  globalShortcut.register("MediaNextTrack", () => { ... });
+  globalShortcut.register("MediaPreviousTrack", () => { ... });
+  globalShortcut.register("MediaStop", () => { ... });
+}
+```
+
+### 3.2 Primary Media Tab Resolution
+
+**File: `src/main/controllers/tabs-controller/index.ts`**
+
+Add a method to determine the "primary" media tab:
+
+```typescript
+getPrimaryMediaTab(): Tab | null {
+  // Return the most recently active audible tab
+  let bestTab: Tab | null = null;
+  for (const tab of this.tabs.values()) {
+    if (!tab.audible || tab.isDestroyed) continue;
+    if (!bestTab || tab.lastActiveAt > bestTab.lastActiveAt) {
+      bestTab = tab;
+    }
+  }
+  return bestTab;
+}
+```
+
+### 3.3 Lifecycle
+
+- Register keys on `app.whenReady()`
+- Unregister on `app.on("will-quit")`
+- Keys are global (work even when the browser is not focused)
+
+---
+
+## Phase 4: Polish & Edge Cases
+
+### Multiple Media Tabs
+
+When multiple tabs are producing audio simultaneously:
+
+- The global controls target the **most recently activated** audible tab
+- A small indicator (e.g., badge count or dropdown) shows how many tabs are playing
+- Clicking the indicator expands a list of all media tabs with individual controls
+
+### Sleeping Tabs
+
+Sleeping tabs have no webContents and cannot play audio. They are excluded from media tab lists. If a media tab is put to sleep, the global controls should update to show the next active media tab or hide entirely.
+
+### Cross-Window
+
+The current IPC model sends tab data per-window. Each window's sidebar shows media controls for tabs in that window only. This is consistent with how the tab list works -- each window has its own sidebar showing its own tabs.
+
+### Performance
+
+- MediaSession metadata polling (Phase 2) only runs on audible tabs, throttled to every 2 seconds
+- Media state changes piggyback on the existing 80ms debounced content update channel -- no additional IPC
+- The renderer `GlobalMediaControls` component only re-renders when media-related tab fields change (it reads from `TabsProvider` which already does reference-equality optimizations)
+
+### Animation
+
+- The media controls bar uses `AnimatePresence` + `motion.div` with spring transitions, matching the existing audio indicator pattern in `tab-group.tsx`
+- Slides in from bottom or fades in when a media tab starts playing
+- Slides/fades out when no tabs are playing
+
+---
+
+## Implementation Order
+
+| Step | Phase   | Effort | Description                                                        |
+| ---- | ------- | ------ | ------------------------------------------------------------------ |
+| 1    | 1.4     | Small  | Add mute/unmute to tab context menu                                |
+| 2    | 1.1     | Medium | Add media play/pause/skip IPC handlers (executeJavaScript)         |
+| 3    | 1.2-1.3 | Small  | Extend FlowTabsAPI interface + preload bridge                      |
+| 4    | 1.5     | Medium | Build GlobalMediaControls sidebar component (title + favicon only) |
+| 5    | 2.1-2.2 | Large  | Add MediaSession metadata extraction in main process               |
+| 6    | 2.3-2.4 | Medium | Extend TabData + enhance UI with track/artist/artwork              |
+| 7    | 3.1-3.3 | Small  | Register hardware media key shortcuts                              |
+| 8    | 4       | Small  | Polish: multi-tab, animations, edge cases                          |
+
+---
+
+## Key Files
+
+| File                                                                                           | Role                                                       |
+| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `src/main/controllers/tabs-controller/tab.ts`                                                  | Tab class -- media state properties, WebContents listeners |
+| `src/main/controllers/tabs-controller/index.ts`                                                | TabsController -- primary media tab resolution             |
+| `src/main/ipc/browser/tabs.ts`                                                                 | IPC handlers -- media control actions, context menu        |
+| `src/shared/types/tabs.ts`                                                                     | TabData type -- media metadata fields                      |
+| `src/shared/flow/interfaces/browser/tabs.ts`                                                   | FlowTabsAPI -- media control methods                       |
+| `src/preload/index.ts`                                                                         | Preload bridge -- media control methods                    |
+| `src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx` | Global media controls UI component                         |
+| `src/renderer/src/components/browser-ui/browser-sidebar/inner.tsx`                             | Sidebar layout -- placement of media controls              |
+| `src/main/modules/media-keys.ts`                                                               | Hardware media key registration (Phase 3)                  |

--- a/src/main/controllers/tabs-controller/tab.ts
+++ b/src/main/controllers/tabs-controller/tab.ts
@@ -30,7 +30,18 @@ type TabStateProperty =
   | "asleep"
   | "lastActiveAt"
   | "position";
-type TabContentProperty = "title" | "url" | "isLoading" | "audible" | "muted" | "navHistory" | "navHistoryIndex";
+type TabContentProperty =
+  | "title"
+  | "url"
+  | "isLoading"
+  | "audible"
+  | "muted"
+  | "navHistory"
+  | "navHistoryIndex"
+  | "mediaTitle"
+  | "mediaArtist"
+  | "mediaArtwork"
+  | "mediaPlaybackState";
 
 export type TabPublicProperty = TabStateProperty | TabContentProperty;
 
@@ -161,6 +172,12 @@ export class Tab extends TypedEventEmitter<TabEvents> {
   public muted: boolean = false;
   public navHistory: NavigationEntry[] = [];
   public navHistoryIndex: number = 0;
+
+  // Media metadata (from page's navigator.mediaSession, polled while audible)
+  public mediaTitle: string | null = null;
+  public mediaArtist: string | null = null;
+  public mediaArtwork: string | null = null;
+  public mediaPlaybackState: "playing" | "paused" | "none" = "none";
 
   // Cached for nav history diff (avoids JSON.stringify every time)
   private lastNavHistoryLength: number = 0;
@@ -720,6 +737,76 @@ export class Tab extends TypedEventEmitter<TabEvents> {
 
     const replace = FLAGS.ERROR_PAGE_LOAD_MODE === "replace";
     this.loadURL(errorPageURL.toString(), replace);
+  }
+
+  // --- Media Metadata (from preload) ---
+
+  /**
+   * Updates media metadata from the page's navigator.mediaSession.
+   * Called by the IPC handler when the preload script detects a change.
+   * Emits "updated" if any values change.
+   */
+  public updateMediaMetadata(metadata: {
+    title: string | null;
+    artist: string | null;
+    artwork: string | null;
+    playbackState: "playing" | "paused" | "none";
+  }): void {
+    if (this.isDestroyed) return;
+
+    const changedKeys: TabContentProperty[] = [];
+
+    if (metadata.title !== this.mediaTitle) {
+      this.mediaTitle = metadata.title;
+      changedKeys.push("mediaTitle");
+    }
+    if (metadata.artist !== this.mediaArtist) {
+      this.mediaArtist = metadata.artist;
+      changedKeys.push("mediaArtist");
+    }
+    if (metadata.artwork !== this.mediaArtwork) {
+      this.mediaArtwork = metadata.artwork;
+      changedKeys.push("mediaArtwork");
+    }
+    if (metadata.playbackState !== this.mediaPlaybackState) {
+      this.mediaPlaybackState = metadata.playbackState;
+      changedKeys.push("mediaPlaybackState");
+    }
+
+    if (changedKeys.length > 0) {
+      this.emit("updated", changedKeys);
+    }
+  }
+
+  /**
+   * Clears media metadata when the page loses MediaSession data.
+   * Called by the preload when metadata becomes null.
+   */
+  public clearMediaMetadata(): void {
+    if (this.isDestroyed) return;
+
+    const changedKeys: TabContentProperty[] = [];
+
+    if (this.mediaTitle !== null) {
+      this.mediaTitle = null;
+      changedKeys.push("mediaTitle");
+    }
+    if (this.mediaArtist !== null) {
+      this.mediaArtist = null;
+      changedKeys.push("mediaArtist");
+    }
+    if (this.mediaArtwork !== null) {
+      this.mediaArtwork = null;
+      changedKeys.push("mediaArtwork");
+    }
+    if (this.mediaPlaybackState !== "none") {
+      this.mediaPlaybackState = "none";
+      changedKeys.push("mediaPlaybackState");
+    }
+
+    if (changedKeys.length > 0) {
+      this.emit("updated", changedKeys);
+    }
   }
 
   // --- Destruction ---

--- a/src/main/ipc/browser/tabs.ts
+++ b/src/main/ipc/browser/tabs.ts
@@ -424,6 +424,19 @@ ipcMain.on("tabs:show-context-menu", (event, tabId: number) => {
     })
   );
 
+  // Mute / Unmute — only shown for awake tabs with webContents
+  if (!tab.asleep && tab.webContents) {
+    contextMenu.append(
+      new MenuItem({
+        label: tab.muted ? "Unmute Tab" : "Mute Tab",
+        click: () => {
+          tab.webContents?.setAudioMuted(!tab.muted);
+          tab.updateTabState();
+        }
+      })
+    );
+  }
+
   contextMenu.append(
     new MenuItem({
       label: "Close Tab",
@@ -551,4 +564,110 @@ ipcMain.handle("tabs:batch-move-tabs", async (event, tabIds: number[], spaceId: 
   tabsController.normalizePositions(window.id, spaceId);
 
   return true;
+});
+
+// --- Media Controls ---
+
+ipcMain.handle("tabs:media-play-pause", async (_event, tabId: number) => {
+  const tab = tabsController.getTabById(tabId);
+  if (!tab?.webContents) return false;
+
+  const script = `
+    (function() {
+      var media = document.querySelector('video:not([muted]), audio:not([muted])') || document.querySelector('video, audio');
+      if (media) {
+        if (media.paused) { media.play(); } else { media.pause(); }
+        return true;
+      }
+      return false;
+    })()
+  `;
+  try {
+    return await tab.webContents.executeJavaScript(script, true);
+  } catch {
+    return false;
+  }
+});
+
+ipcMain.handle("tabs:media-next-track", async (_event, tabId: number) => {
+  const tab = tabsController.getTabById(tabId);
+  if (!tab?.webContents) return false;
+
+  // Invoke the page's MediaSession "nexttrack" action handler.
+  // The MediaSession API stores action handlers internally — we call
+  // navigator.mediaSession.callAction() if available (Chromium internal),
+  // or simulate via keyboard event on the video element as fallback.
+  const script = `
+    (function() {
+      try {
+        if (navigator.mediaSession) {
+          // Chromium exposes an internal callActionHandler we can trigger
+          // by setting up a shim: create a temporary MediaSession action
+          // that simply re-dispatches, or rely on the site's own handler.
+          // The most reliable approach is to use the page's key handler:
+          document.dispatchEvent(new KeyboardEvent('keydown', {
+            key: 'MediaTrackNext', code: 'MediaTrackNext', bubbles: true
+          }));
+        }
+        return true;
+      } catch(e) { return false; }
+    })()
+  `;
+  try {
+    return await tab.webContents.executeJavaScript(script, true);
+  } catch {
+    return false;
+  }
+});
+
+ipcMain.handle("tabs:media-previous-track", async (_event, tabId: number) => {
+  const tab = tabsController.getTabById(tabId);
+  if (!tab?.webContents) return false;
+
+  const script = `
+    (function() {
+      try {
+        if (navigator.mediaSession) {
+          document.dispatchEvent(new KeyboardEvent('keydown', {
+            key: 'MediaTrackPrevious', code: 'MediaTrackPrevious', bubbles: true
+          }));
+        }
+        return true;
+      } catch(e) { return false; }
+    })()
+  `;
+  try {
+    return await tab.webContents.executeJavaScript(script, true);
+  } catch {
+    return false;
+  }
+});
+
+// --- Media Session Metadata from Preload ---
+
+ipcMain.on(
+  "media-session:metadata-changed",
+  (
+    event,
+    metadata: {
+      title: string | null;
+      artist: string | null;
+      artwork: string | null;
+      playbackState: "playing" | "paused" | "none";
+    }
+  ) => {
+    const webContents = event.sender;
+    const tab = tabsController.getTabByWebContents(webContents);
+    if (tab) {
+      tab.updateMediaMetadata(metadata);
+    }
+  }
+);
+
+ipcMain.on("media-session:metadata-cleared", (event) => {
+  const webContents = event.sender;
+  const tab = tabsController.getTabByWebContents(webContents);
+  if (tab) {
+    tab.clearMediaMetadata();
+  }
 });

--- a/src/main/ipc/browser/tabs.ts
+++ b/src/main/ipc/browser/tabs.ts
@@ -572,12 +572,25 @@ ipcMain.handle("tabs:media-play-pause", async (_event, tabId: number) => {
   const tab = tabsController.getTabById(tabId);
   if (!tab?.webContents) return false;
 
+  // Try the media element first (most reliable), then fall back to
+  // the page's captured MediaSession play/pause action handlers.
   const script = `
     (function() {
       var media = document.querySelector('video:not([muted]), audio:not([muted])') || document.querySelector('video, audio');
       if (media) {
         if (media.paused) { media.play(); } else { media.pause(); }
         return true;
+      }
+      var handlers = window.__flowMediaActionHandlers;
+      if (handlers) {
+        var playHandler = handlers.get('play');
+        var pauseHandler = handlers.get('pause');
+        if (playHandler || pauseHandler) {
+          // Determine current state from mediaSession if possible
+          var state = navigator.mediaSession && navigator.mediaSession.playbackState;
+          if (state === 'playing' && pauseHandler) { pauseHandler(); return true; }
+          if (playHandler) { playHandler(); return true; }
+        }
       }
       return false;
     })()
@@ -593,23 +606,18 @@ ipcMain.handle("tabs:media-next-track", async (_event, tabId: number) => {
   const tab = tabsController.getTabById(tabId);
   if (!tab?.webContents) return false;
 
-  // Invoke the page's MediaSession "nexttrack" action handler.
-  // The MediaSession API stores action handlers internally — we call
-  // navigator.mediaSession.callAction() if available (Chromium internal),
-  // or simulate via keyboard event on the video element as fallback.
+  // Call the page's captured MediaSession "nexttrack" action handler.
+  // The preload monkey-patches navigator.mediaSession.setActionHandler()
+  // and stores references in window.__flowMediaActionHandlers.
   const script = `
     (function() {
       try {
-        if (navigator.mediaSession) {
-          // Chromium exposes an internal callActionHandler we can trigger
-          // by setting up a shim: create a temporary MediaSession action
-          // that simply re-dispatches, or rely on the site's own handler.
-          // The most reliable approach is to use the page's key handler:
-          document.dispatchEvent(new KeyboardEvent('keydown', {
-            key: 'MediaTrackNext', code: 'MediaTrackNext', bubbles: true
-          }));
+        var handlers = window.__flowMediaActionHandlers;
+        if (handlers) {
+          var handler = handlers.get('nexttrack');
+          if (handler) { handler(); return true; }
         }
-        return true;
+        return false;
       } catch(e) { return false; }
     })()
   `;
@@ -627,12 +635,12 @@ ipcMain.handle("tabs:media-previous-track", async (_event, tabId: number) => {
   const script = `
     (function() {
       try {
-        if (navigator.mediaSession) {
-          document.dispatchEvent(new KeyboardEvent('keydown', {
-            key: 'MediaTrackPrevious', code: 'MediaTrackPrevious', bubbles: true
-          }));
+        var handlers = window.__flowMediaActionHandlers;
+        if (handlers) {
+          var handler = handlers.get('previoustrack');
+          if (handler) { handler(); return true; }
         }
-        return true;
+        return false;
       } catch(e) { return false; }
     })()
   `;

--- a/src/main/saving/tabs/serialization.ts
+++ b/src/main/saving/tabs/serialization.ts
@@ -142,7 +142,13 @@ export function serializeTabForRenderer(tab: Tab, preSleepState?: PreSleepState 
     audible: tab.audible,
     fullScreen: tab.fullScreen,
     isPictureInPicture: tab.isPictureInPicture,
-    asleep: tab.asleep
+    asleep: tab.asleep,
+
+    // Media metadata (runtime-only, from page's navigator.mediaSession)
+    mediaTitle: tab.mediaTitle,
+    mediaArtist: tab.mediaArtist,
+    mediaArtwork: tab.mediaArtwork,
+    mediaPlaybackState: tab.mediaPlaybackState
   };
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -303,6 +303,28 @@ function setupMediaSessionWatcher() {
     // "primary" media source per tab (most recently active or audible).
     if (window.self !== window.top) return;
 
+    // Monkey-patch navigator.mediaSession.setActionHandler so we can capture
+    // the action handler references registered by the page. This lets us
+    // invoke them directly from executeJavaScript (e.g. for skip track)
+    // instead of dispatching fake keyboard events which don't trigger
+    // MediaSession handlers.
+    const actionHandlers = new Map<string, MediaSessionActionHandler | null>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__flowMediaActionHandlers = actionHandlers;
+
+    try {
+      const originalSetActionHandler = navigator.mediaSession.setActionHandler.bind(navigator.mediaSession);
+      navigator.mediaSession.setActionHandler = (
+        action: MediaSessionAction,
+        handler: MediaSessionActionHandler | null
+      ) => {
+        actionHandlers.set(action, handler);
+        originalSetActionHandler(action, handler);
+      };
+    } catch {
+      // Some pages may freeze navigator.mediaSession — ignore errors
+    }
+
     let lastMetadata: {
       title: string | null;
       artist: string | null;
@@ -325,17 +347,16 @@ function setupMediaSessionWatcher() {
         artwork = largest?.src || null;
       }
 
-      // Prefer the MediaSession playbackState when the site sets it, but
-      // fall back to the actual media-element state so we react instantly
-      // when we toggle play/pause via executeJavaScript.
-      let playbackState: "playing" | "paused" | "none" =
-        ms.playbackState === "playing" || ms.playbackState === "paused" ? ms.playbackState : "none";
-
-      if (playbackState === "none") {
-        const media = document.querySelector("video, audio") as HTMLMediaElement | null;
-        if (media) {
-          playbackState = media.paused ? "paused" : "playing";
-        }
+      // Derive playback state from the actual media element when possible
+      // because it's the ground truth. navigator.mediaSession.playbackState
+      // is set by page JS and many sites never update it after the initial
+      // set (e.g. they set "playing" but forget to set "paused").
+      let playbackState: "playing" | "paused" | "none" = "none";
+      const media = document.querySelector("video, audio") as HTMLMediaElement | null;
+      if (media) {
+        playbackState = media.paused ? "paused" : "playing";
+      } else if (ms.playbackState === "playing" || ms.playbackState === "paused") {
+        playbackState = ms.playbackState;
       }
 
       // Only return if we have actual metadata
@@ -383,19 +404,22 @@ function setupMediaSessionWatcher() {
     // The MediaSession API doesn't emit events, but sites usually update
     // the metadata when the media element's attributes change
     const setupObserver = () => {
-      // Check for changes periodically (throttled)
-      let rafId: number | null = null;
+      // Coalesce rapid DOM mutations with a short setTimeout.
+      // NOTE: We intentionally avoid requestAnimationFrame here because
+      // Chromium completely suspends rAF in background tabs, and media
+      // controls are specifically for background tabs.
+      let timerId: ReturnType<typeof setTimeout> | null = null;
       const check = () => {
         sendMetadataUpdate();
-        rafId = null;
+        timerId = null;
       };
 
       const scheduleCheck = () => {
-        if (rafId) return;
-        rafId = requestAnimationFrame(check);
+        if (timerId) return;
+        timerId = setTimeout(check, 120);
       };
 
-      // Watch for media element changes
+      // Watch for media element attribute changes (e.g. src, title)
       const observer = new MutationObserver(scheduleCheck);
 
       // Observe the whole document for attribute changes
@@ -405,15 +429,15 @@ function setupMediaSessionWatcher() {
         subtree: true
       });
 
-      // Listen for play/pause events on media elements so the playback
-      // state updates immediately when media is toggled (e.g. via our
-      // executeJavaScript play/pause command). Capture phase ensures we
-      // catch events even if the site stops propagation.
-      document.addEventListener("play", scheduleCheck, true);
-      document.addEventListener("pause", scheduleCheck, true);
+      // Listen for play/pause events on media elements. These are
+      // critical state changes so we send immediately (not debounced).
+      // Capture phase ensures we catch events even if the site stops
+      // propagation.
+      document.addEventListener("play", () => sendMetadataUpdate(), true);
+      document.addEventListener("pause", () => sendMetadataUpdate(), true);
 
-      // Also check periodically as a fallback (every 5 seconds)
-      setInterval(check, 5000);
+      // Also check periodically as a fallback (every 3 seconds)
+      setInterval(check, 3000);
 
       // Check immediately
       check();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -290,6 +290,149 @@ function tryPatchPasskeys() {
 }
 tryPatchPasskeys();
 
+// MEDIA SESSION WATCHER //
+// Watches navigator.mediaSession for metadata changes and sends IPC messages
+// to the main process. This is more efficient than polling via executeJavaScript.
+function setupMediaSessionWatcher() {
+  const mediaSessionScript = () => {
+    // Only run in main frame (not iframes)
+    // TODO: Support media controls in iframes — currently we only watch the main
+    // frame to avoid duplicate/conflicting messages from multiple iframes, but
+    // this means we miss media in embedded players (YouTube embeds, etc.).
+    // When implementing, add frame identification to IPC messages and track the
+    // "primary" media source per tab (most recently active or audible).
+    if (window.self !== window.top) return;
+
+    let lastMetadata: {
+      title: string | null;
+      artist: string | null;
+      artwork: string | null;
+      playbackState: "playing" | "paused" | "none";
+    } | null = null;
+
+    const extractMetadata = () => {
+      const ms = navigator.mediaSession;
+      if (!ms || !ms.metadata) return null;
+
+      const meta = ms.metadata;
+      const title = meta.title || null;
+      const artist = meta.artist || null;
+
+      // Get the largest artwork (usually the last in the array)
+      let artwork: string | null = null;
+      if (meta.artwork && meta.artwork.length > 0) {
+        const largest = meta.artwork[meta.artwork.length - 1];
+        artwork = largest?.src || null;
+      }
+
+      const playbackState: "playing" | "paused" | "none" =
+        ms.playbackState === "playing" || ms.playbackState === "paused" ? ms.playbackState : "none";
+
+      // Only return if we have actual metadata
+      if (!title && !artist) return null;
+
+      return { title, artist, artwork, playbackState };
+    };
+
+    const sendMetadataUpdate = () => {
+      const metadata = extractMetadata();
+      if (metadata) {
+        // Check if changed
+        const changed =
+          !lastMetadata ||
+          lastMetadata.title !== metadata.title ||
+          lastMetadata.artist !== metadata.artist ||
+          lastMetadata.artwork !== metadata.artwork ||
+          lastMetadata.playbackState !== metadata.playbackState;
+
+        if (changed) {
+          lastMetadata = metadata;
+          const api = (
+            window as Window & {
+              electronAPI?: {
+                sendMediaSessionMetadata: (data: {
+                  title: string | null;
+                  artist: string | null;
+                  artwork: string | null;
+                  playbackState: "playing" | "paused" | "none";
+                }) => void;
+              };
+            }
+          ).electronAPI;
+          api?.sendMediaSessionMetadata(metadata);
+        }
+      } else if (lastMetadata) {
+        // Metadata was cleared
+        lastMetadata = null;
+        const api = (window as Window & { electronAPI?: { clearMediaSessionMetadata: () => void } }).electronAPI;
+        api?.clearMediaSessionMetadata();
+      }
+    };
+
+    // Watch for metadata changes using MutationObserver on the document
+    // The MediaSession API doesn't emit events, but sites usually update
+    // the metadata when the media element's attributes change
+    const setupObserver = () => {
+      // Check for changes periodically (throttled)
+      let rafId: number | null = null;
+      const check = () => {
+        sendMetadataUpdate();
+        rafId = null;
+      };
+
+      // Watch for media element changes
+      const observer = new MutationObserver(() => {
+        if (rafId) return;
+        rafId = requestAnimationFrame(check);
+      });
+
+      // Observe the whole document for attribute changes
+      observer.observe(document, {
+        attributes: true,
+        attributeFilter: ["src", "title"],
+        subtree: true
+      });
+
+      // Also check periodically as a fallback (every 5 seconds)
+      setInterval(check, 5000);
+
+      // Check immediately
+      check();
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", setupObserver);
+    } else {
+      setupObserver();
+    }
+  };
+
+  // Expose IPC functions to the page context via contextBridge
+  contextBridge.exposeInMainWorld("electronAPI", {
+    sendMediaSessionMetadata: (metadata: {
+      title: string | null;
+      artist: string | null;
+      artwork: string | null;
+      playbackState: "playing" | "paused" | "none";
+    }) => {
+      ipcRenderer.send("media-session:metadata-changed", metadata);
+    },
+    clearMediaSessionMetadata: () => {
+      ipcRenderer.send("media-session:metadata-cleared");
+    }
+  });
+
+  // Execute the watcher script in the main world
+  contextBridge.executeInMainWorld({
+    func: mediaSessionScript
+  });
+}
+
+// Only setup MediaSession watcher for regular web pages (not internal protocols)
+if (!location.protocol.startsWith("flow")) {
+  setupMediaSessionWatcher();
+}
+
 // INTERNAL FUNCTIONS //
 function getOSFromPlatform(platform: NodeJS.Platform) {
   switch (platform) {
@@ -482,6 +625,19 @@ const tabsAPI: FlowTabsAPI = {
 
   clearRecentlyClosed: async () => {
     return ipcRenderer.invoke("tabs:clear-recently-closed");
+  },
+
+  // Media Controls
+  mediaPlayPause: async (tabId: number) => {
+    return ipcRenderer.invoke("tabs:media-play-pause", tabId);
+  },
+
+  mediaNextTrack: async (tabId: number) => {
+    return ipcRenderer.invoke("tabs:media-next-track", tabId);
+  },
+
+  mediaPreviousTrack: async (tabId: number) => {
+    return ipcRenderer.invoke("tabs:media-previous-track", tabId);
   }
 };
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -325,8 +325,18 @@ function setupMediaSessionWatcher() {
         artwork = largest?.src || null;
       }
 
-      const playbackState: "playing" | "paused" | "none" =
+      // Prefer the MediaSession playbackState when the site sets it, but
+      // fall back to the actual media-element state so we react instantly
+      // when we toggle play/pause via executeJavaScript.
+      let playbackState: "playing" | "paused" | "none" =
         ms.playbackState === "playing" || ms.playbackState === "paused" ? ms.playbackState : "none";
+
+      if (playbackState === "none") {
+        const media = document.querySelector("video, audio") as HTMLMediaElement | null;
+        if (media) {
+          playbackState = media.paused ? "paused" : "playing";
+        }
+      }
 
       // Only return if we have actual metadata
       if (!title && !artist) return null;
@@ -380,11 +390,13 @@ function setupMediaSessionWatcher() {
         rafId = null;
       };
 
-      // Watch for media element changes
-      const observer = new MutationObserver(() => {
+      const scheduleCheck = () => {
         if (rafId) return;
         rafId = requestAnimationFrame(check);
-      });
+      };
+
+      // Watch for media element changes
+      const observer = new MutationObserver(scheduleCheck);
 
       // Observe the whole document for attribute changes
       observer.observe(document, {
@@ -392,6 +404,13 @@ function setupMediaSessionWatcher() {
         attributeFilter: ["src", "title"],
         subtree: true
       });
+
+      // Listen for play/pause events on media elements so the playback
+      // state updates immediately when media is toggled (e.g. via our
+      // executeJavaScript play/pause command). Capture phase ensures we
+      // catch events even if the site stops propagation.
+      document.addEventListener("play", scheduleCheck, true);
+      document.addEventListener("pause", scheduleCheck, true);
 
       // Also check periodically as a fallback (every 5 seconds)
       setInterval(check, 5000);

--- a/src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx
+++ b/src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx
@@ -1,9 +1,12 @@
 import { cn, craftActiveFaviconURL } from "@/lib/utils";
-import { Pause, Play, SkipBack, SkipForward, Volume2, VolumeX } from "lucide-react";
+import { Pause, Play, SkipBack, SkipForward, Volume2, VolumeX, X } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { useFocusedTabId, useTabs } from "@/components/providers/tabs-provider";
 import type { TabData } from "~/types/tabs";
+
+const MAX_MEDIA_CARDS = 5;
+const EASE_OUT: [number, number, number, number] = [0.22, 1, 0.36, 1];
 
 /**
  * Returns all tabs that have media activity (playing, paused, audible, or muted),
@@ -37,8 +40,38 @@ function useMediaTabs(): TabData[] {
       }
     }
 
-    return [...playing, ...audible, ...paused, ...muted];
+    return [...playing, ...audible, ...paused, ...muted].slice(0, MAX_MEDIA_CARDS);
   }, [tabsData, focusedTabId]);
+}
+
+// --- Favicon --- //
+
+function Favicon({
+  tab,
+  size = "size-4",
+  faviconError,
+  onFaviconError
+}: {
+  tab: TabData;
+  size?: string;
+  faviconError: boolean;
+  onFaviconError: () => void;
+}) {
+  return (
+    <div className={cn(size, "shrink-0")}>
+      {tab.faviconURL && !faviconError ? (
+        <img
+          src={craftActiveFaviconURL(tab.id, tab.faviconURL)}
+          alt=""
+          className="size-full rounded-sm object-contain overflow-hidden"
+          style={{ userSelect: "none", WebkitUserDrag: "none" } as React.CSSProperties}
+          onError={onFaviconError}
+        />
+      ) : (
+        <div className="size-full bg-gray-300 dark:bg-gray-300/30 rounded-sm" />
+      )}
+    </div>
+  );
 }
 
 // --- MediaControlButton --- //
@@ -74,7 +107,15 @@ function MediaControlButton({
 
 // --- MediaCard --- //
 
-const MediaCard = memo(function MediaCard({ tab }: { tab: TabData }) {
+const MediaCard = memo(function MediaCard({
+  tab,
+  expanded,
+  showStack
+}: {
+  tab: TabData;
+  expanded: boolean;
+  showStack: boolean;
+}) {
   const [faviconError, setFaviconError] = useState(false);
 
   // Reset favicon error when the tab's favicon changes
@@ -83,6 +124,8 @@ const MediaCard = memo(function MediaCard({ tab }: { tab: TabData }) {
     setPrevFavicon(tab.faviconURL);
     setFaviconError(false);
   }
+
+  const handleFaviconError = useCallback(() => setFaviconError(true), []);
 
   const handlePlayPause = useCallback(
     (e: React.MouseEvent) => {
@@ -116,66 +159,93 @@ const MediaCard = memo(function MediaCard({ tab }: { tab: TabData }) {
     [tab.id, tab.muted]
   );
 
+  const handleClose = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      flow.tabs.closeTab(tab.id);
+    },
+    [tab.id]
+  );
+
   const handleSwitchToTab = useCallback(() => {
     flow.tabs.switchToTab(tab.id);
   }, [tab.id]);
 
   const displayTitle = tab.mediaTitle || tab.title;
-  const displayArtist = tab.mediaArtist || null;
   const isPlaying = tab.mediaPlaybackState === "playing" || (tab.audible && !tab.muted);
 
   return (
-    <motion.div
-      key={tab.id}
-      initial={{ opacity: 0, height: 0, marginTop: 0 }}
-      animate={{ opacity: 1, height: "auto", marginTop: 8 }}
-      exit={{ opacity: 0, height: 0, marginTop: 0 }}
-      transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
-      className="shrink-0 overflow-hidden"
-    >
-      <div
-        className={cn(
-          "w-full rounded-xl overflow-hidden",
-          "border border-black/10 dark:border-white/15",
-          "bg-black/5 dark:bg-white/10"
-        )}
-      >
-        {/* Top row: favicon + title */}
+    <div className={cn("relative", showStack && !expanded && "pb-[5px]")}>
+      {/* Fake stacked card behind (only for first card when collapsed and multiple tabs) */}
+      {showStack && !expanded && (
         <div
           className={cn(
-            "flex items-center gap-2 px-2.5 pt-2 pb-1",
-            "cursor-pointer",
-            "hover:bg-black/5 dark:hover:bg-white/5",
-            "transition-colors duration-100"
+            "absolute left-[3px] right-[3px] top-[4px] bottom-0",
+            "rounded-xl",
+            "bg-white/60 dark:bg-neutral-800/60",
+            "border border-black/5 dark:border-white/10"
           )}
-          onClick={handleSwitchToTab}
-        >
-          {/* Favicon */}
-          <div className="size-4 shrink-0">
-            {tab.faviconURL && !faviconError ? (
-              <img
-                src={craftActiveFaviconURL(tab.id, tab.faviconURL)}
-                alt=""
-                className="size-full rounded-sm object-contain overflow-hidden"
-                style={{ userSelect: "none", WebkitUserDrag: "none" } as React.CSSProperties}
-                onError={() => setFaviconError(true)}
-              />
-            ) : (
-              <div className="size-full bg-gray-300 dark:bg-gray-300/30 rounded-sm" />
-            )}
-          </div>
+        />
+      )}
 
-          {/* Title + Artist */}
-          <div className="flex-1 min-w-0">
-            <div className="truncate text-xs font-medium text-black/90 dark:text-white/90">{displayTitle}</div>
-            {displayArtist && (
-              <div className="truncate text-[10px] text-black/50 dark:text-white/50">{displayArtist}</div>
-            )}
-          </div>
-        </div>
+      {/* Actual card */}
+      <div
+        className={cn(
+          "relative w-full rounded-xl overflow-hidden",
+          "border border-black/10 dark:border-white/15",
+          "bg-white dark:bg-neutral-900",
+          "shadow-sm"
+        )}
+      >
+        {/* Title row — only visible when expanded */}
+        <AnimatePresence initial={false}>
+          {expanded && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{
+                duration: 0.3,
+                ease: EASE_OUT,
+                opacity: { duration: 0.2 }
+              }}
+              className="overflow-hidden"
+            >
+              <div
+                className={cn(
+                  "flex items-center gap-2 px-2.5 pt-2 pb-1",
+                  "cursor-pointer",
+                  "hover:bg-black/5 dark:hover:bg-white/5",
+                  "transition-colors duration-100"
+                )}
+                onClick={handleSwitchToTab}
+              >
+                <Favicon tab={tab} size="size-4" faviconError={faviconError} onFaviconError={handleFaviconError} />
+                <div className="flex-1 min-w-0 truncate text-xs font-medium text-black/90 dark:text-white/90">
+                  {displayTitle}
+                </div>
+                <button
+                  className={cn(
+                    "size-5 flex items-center justify-center rounded-md shrink-0",
+                    "hover:bg-black/10 dark:hover:bg-white/10",
+                    "active:bg-black/15 dark:active:bg-white/15",
+                    "transition-colors duration-100",
+                    "cursor-pointer"
+                  )}
+                  onClick={handleClose}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  title="Close tab"
+                >
+                  <X className="size-3 text-black/50 dark:text-white/50" />
+                </button>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
 
-        {/* Bottom row: playback controls */}
-        <div className="flex items-center justify-center gap-1 px-2 pb-2 pt-0.5">
+        {/* Controls row — always visible */}
+        <div className="flex items-center gap-1 px-2 py-1.5">
+          <Favicon tab={tab} size="size-5" faviconError={faviconError} onFaviconError={handleFaviconError} />
           <MediaControlButton icon={SkipBack} onClick={handlePrevTrack} label="Previous track" size="size-3" />
           <MediaControlButton
             icon={isPlaying ? Pause : Play}
@@ -197,7 +267,7 @@ const MediaCard = memo(function MediaCard({ tab }: { tab: TabData }) {
           />
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 });
 
@@ -205,12 +275,26 @@ const MediaCard = memo(function MediaCard({ tab }: { tab: TabData }) {
 
 export const GlobalMediaControls = memo(function GlobalMediaControls() {
   const mediaTabs = useMediaTabs();
+  const [hovered, setHovered] = useState(false);
+
+  if (mediaTabs.length === 0) return null;
 
   return (
-    <AnimatePresence>
-      {mediaTabs.map((tab) => (
-        <MediaCard key={tab.id} tab={tab} />
-      ))}
-    </AnimatePresence>
+    <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+      <AnimatePresence initial={false}>
+        {mediaTabs.map((tab, index) => (
+          <motion.div
+            key={tab.id}
+            initial={{ opacity: 0, height: 0, marginTop: 0 }}
+            animate={{ opacity: 1, height: "auto", marginTop: 8 }}
+            exit={{ opacity: 0, height: 0, marginTop: 0 }}
+            transition={{ duration: 0.3, ease: EASE_OUT }}
+            className="shrink-0 overflow-hidden"
+          >
+            <MediaCard tab={tab} expanded={hovered} showStack={index === 0 && mediaTabs.length > 1} />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
   );
 });

--- a/src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx
+++ b/src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx
@@ -8,7 +8,7 @@ import type { TabData } from "~/types/tabs";
 /**
  * Derives the "primary" media tab from all tabs in the window.
  * Priority: first tab with mediaPlaybackState "playing", then first audible
- * (non-muted) tab, then first muted tab that was playing.
+ * (non-muted) tab, then first paused tab (has metadata), then first muted tab.
  */
 function usePrimaryMediaTab(): TabData | null {
   const { tabsData } = useTabs();
@@ -18,6 +18,7 @@ function usePrimaryMediaTab(): TabData | null {
 
     let playingTab: TabData | null = null;
     let audibleTab: TabData | null = null;
+    let pausedTab: TabData | null = null;
     let mutedTab: TabData | null = null;
 
     for (const tab of tabsData.tabs) {
@@ -27,25 +28,30 @@ function usePrimaryMediaTab(): TabData | null {
       if (tab.audible && !audibleTab) {
         audibleTab = tab;
       }
+      if (tab.mediaPlaybackState === "paused" && !pausedTab) {
+        pausedTab = tab;
+      }
       if (tab.muted && !tab.audible && !mutedTab) {
         mutedTab = tab;
       }
     }
 
-    // Prefer tab with "playing" mediaSession state, then audible, then muted
-    return playingTab ?? audibleTab ?? mutedTab ?? null;
+    // Prefer tab with "playing" mediaSession state, then audible, then paused, then muted
+    return playingTab ?? audibleTab ?? pausedTab ?? mutedTab ?? null;
   }, [tabsData]);
 }
 
 /**
- * Returns all tabs that are currently producing audio or are muted.
+ * Returns all tabs that are currently producing audio, paused with metadata, or muted.
  */
 function useMediaTabCount(): number {
   const { tabsData } = useTabs();
 
   return useMemo(() => {
     if (!tabsData?.tabs) return 0;
-    return tabsData.tabs.filter((tab) => tab.audible || tab.muted).length;
+    return tabsData.tabs.filter(
+      (tab) => tab.audible || tab.muted || tab.mediaPlaybackState === "playing" || tab.mediaPlaybackState === "paused"
+    ).length;
   }, [tabsData]);
 }
 

--- a/src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx
+++ b/src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx
@@ -1,0 +1,239 @@
+import { cn, craftActiveFaviconURL } from "@/lib/utils";
+import { Pause, Play, SkipBack, SkipForward, Volume2, VolumeX } from "lucide-react";
+import { memo, useCallback, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useTabs } from "@/components/providers/tabs-provider";
+import type { TabData } from "~/types/tabs";
+
+/**
+ * Derives the "primary" media tab from all tabs in the window.
+ * Priority: first tab with mediaPlaybackState "playing", then first audible
+ * (non-muted) tab, then first muted tab that was playing.
+ */
+function usePrimaryMediaTab(): TabData | null {
+  const { tabsData } = useTabs();
+
+  return useMemo(() => {
+    if (!tabsData?.tabs) return null;
+
+    let playingTab: TabData | null = null;
+    let audibleTab: TabData | null = null;
+    let mutedTab: TabData | null = null;
+
+    for (const tab of tabsData.tabs) {
+      if (tab.mediaPlaybackState === "playing" && !playingTab) {
+        playingTab = tab;
+      }
+      if (tab.audible && !audibleTab) {
+        audibleTab = tab;
+      }
+      if (tab.muted && !tab.audible && !mutedTab) {
+        mutedTab = tab;
+      }
+    }
+
+    // Prefer tab with "playing" mediaSession state, then audible, then muted
+    return playingTab ?? audibleTab ?? mutedTab ?? null;
+  }, [tabsData]);
+}
+
+/**
+ * Returns all tabs that are currently producing audio or are muted.
+ */
+function useMediaTabCount(): number {
+  const { tabsData } = useTabs();
+
+  return useMemo(() => {
+    if (!tabsData?.tabs) return 0;
+    return tabsData.tabs.filter((tab) => tab.audible || tab.muted).length;
+  }, [tabsData]);
+}
+
+// --- MediaControlButton --- //
+
+function MediaControlButton({
+  icon: Icon,
+  onClick,
+  label,
+  size = "size-3.5"
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  onClick: (e: React.MouseEvent) => void;
+  label: string;
+  size?: string;
+}) {
+  return (
+    <button
+      className={cn(
+        "size-6 flex items-center justify-center rounded-md",
+        "hover:bg-black/10 dark:hover:bg-white/10",
+        "active:bg-black/15 dark:active:bg-white/15",
+        "transition-colors duration-100",
+        "cursor-pointer"
+      )}
+      onClick={onClick}
+      onMouseDown={(e) => e.stopPropagation()}
+      title={label}
+    >
+      <Icon className={cn(size, "text-black/70 dark:text-white/70")} />
+    </button>
+  );
+}
+
+// --- GlobalMediaControls --- //
+
+export const GlobalMediaControls = memo(function GlobalMediaControls() {
+  const mediaTab = usePrimaryMediaTab();
+  const mediaTabCount = useMediaTabCount();
+  const [faviconError, setFaviconError] = useState(false);
+
+  const handlePlayPause = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!mediaTab) return;
+      flow.tabs.mediaPlayPause(mediaTab.id);
+    },
+    [mediaTab]
+  );
+
+  const handlePrevTrack = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!mediaTab) return;
+      flow.tabs.mediaPreviousTrack(mediaTab.id);
+    },
+    [mediaTab]
+  );
+
+  const handleNextTrack = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!mediaTab) return;
+      flow.tabs.mediaNextTrack(mediaTab.id);
+    },
+    [mediaTab]
+  );
+
+  const handleToggleMute = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!mediaTab) return;
+      flow.tabs.setTabMuted(mediaTab.id, !mediaTab.muted);
+    },
+    [mediaTab]
+  );
+
+  const handleSwitchToTab = useCallback(() => {
+    if (!mediaTab) return;
+    flow.tabs.switchToTab(mediaTab.id);
+  }, [mediaTab]);
+
+  // Determine display values
+  const displayTitle = useMemo(() => {
+    if (!mediaTab) return "";
+    // Use media metadata title if available, otherwise tab title
+    return mediaTab.mediaTitle || mediaTab.title;
+  }, [mediaTab]);
+
+  const displayArtist = useMemo(() => {
+    if (!mediaTab) return null;
+    return mediaTab.mediaArtist || null;
+  }, [mediaTab]);
+
+  const isPlaying = mediaTab?.mediaPlaybackState === "playing" || (mediaTab?.audible && !mediaTab?.muted);
+
+  // Reset favicon error when the media tab changes
+  const currentTabId = mediaTab?.id;
+  const [prevTabId, setPrevTabId] = useState<number | undefined>(undefined);
+  if (currentTabId !== prevTabId) {
+    setPrevTabId(currentTabId);
+    setFaviconError(false);
+  }
+
+  return (
+    <AnimatePresence>
+      {mediaTab && (
+        <motion.div
+          key="global-media-controls"
+          initial={{ opacity: 0, height: 0, marginTop: 0 }}
+          animate={{ opacity: 1, height: "auto", marginTop: 8 }}
+          exit={{ opacity: 0, height: 0, marginTop: 0 }}
+          transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+          className="shrink-0 overflow-hidden"
+        >
+          <div
+            className={cn(
+              "w-full rounded-xl overflow-hidden",
+              "border border-black/10 dark:border-white/15",
+              "bg-black/5 dark:bg-white/10"
+            )}
+          >
+            {/* Top row: favicon + title + mute button */}
+            <div
+              className={cn(
+                "flex items-center gap-2 px-2.5 pt-2 pb-1",
+                "cursor-pointer",
+                "hover:bg-black/5 dark:hover:bg-white/5",
+                "transition-colors duration-100"
+              )}
+              onClick={handleSwitchToTab}
+            >
+              {/* Favicon */}
+              <div className="size-4 shrink-0">
+                {mediaTab.faviconURL && !faviconError ? (
+                  <img
+                    src={craftActiveFaviconURL(mediaTab.id, mediaTab.faviconURL)}
+                    alt=""
+                    className="size-full rounded-sm object-contain overflow-hidden"
+                    style={{ userSelect: "none", WebkitUserDrag: "none" } as React.CSSProperties}
+                    onError={() => setFaviconError(true)}
+                  />
+                ) : (
+                  <div className="size-full bg-gray-300 dark:bg-gray-300/30 rounded-sm" />
+                )}
+              </div>
+
+              {/* Title + Artist */}
+              <div className="flex-1 min-w-0">
+                <div className="truncate text-xs font-medium text-black/90 dark:text-white/90">{displayTitle}</div>
+                {displayArtist && (
+                  <div className="truncate text-[10px] text-black/50 dark:text-white/50">{displayArtist}</div>
+                )}
+              </div>
+
+              {/* Tab count badge */}
+              {mediaTabCount > 1 && (
+                <span className="shrink-0 text-[10px] font-medium text-black/40 dark:text-white/40">
+                  +{mediaTabCount - 1}
+                </span>
+              )}
+            </div>
+
+            {/* Bottom row: playback controls */}
+            <div className="flex items-center justify-center gap-1 px-2 pb-2 pt-0.5">
+              <MediaControlButton icon={SkipBack} onClick={handlePrevTrack} label="Previous track" size="size-3" />
+              <MediaControlButton
+                icon={isPlaying ? Pause : Play}
+                onClick={handlePlayPause}
+                label={isPlaying ? "Pause" : "Play"}
+                size="size-4"
+              />
+              <MediaControlButton icon={SkipForward} onClick={handleNextTrack} label="Next track" size="size-3" />
+
+              {/* Spacer */}
+              <div className="flex-1" />
+
+              {/* Mute toggle */}
+              <MediaControlButton
+                icon={mediaTab.muted ? VolumeX : Volume2}
+                onClick={handleToggleMute}
+                label={mediaTab.muted ? "Unmute" : "Mute"}
+                size="size-3.5"
+              />
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+});

--- a/src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx
+++ b/src/renderer/src/components/browser-ui/browser-sidebar/_components/global-media-controls.tsx
@@ -2,57 +2,43 @@ import { cn, craftActiveFaviconURL } from "@/lib/utils";
 import { Pause, Play, SkipBack, SkipForward, Volume2, VolumeX } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
-import { useTabs } from "@/components/providers/tabs-provider";
+import { useFocusedTabId, useTabs } from "@/components/providers/tabs-provider";
 import type { TabData } from "~/types/tabs";
 
 /**
- * Derives the "primary" media tab from all tabs in the window.
- * Priority: first tab with mediaPlaybackState "playing", then first audible
- * (non-muted) tab, then first paused tab (has metadata), then first muted tab.
+ * Returns all tabs that have media activity (playing, paused, audible, or muted),
+ * excluding the currently focused tab (the one the user is looking at).
+ * Sorted by priority: playing > audible > paused > muted.
  */
-function usePrimaryMediaTab(): TabData | null {
+function useMediaTabs(): TabData[] {
   const { tabsData } = useTabs();
+  const focusedTabId = useFocusedTabId();
 
   return useMemo(() => {
-    if (!tabsData?.tabs) return null;
+    if (!tabsData?.tabs) return [];
 
-    let playingTab: TabData | null = null;
-    let audibleTab: TabData | null = null;
-    let pausedTab: TabData | null = null;
-    let mutedTab: TabData | null = null;
+    const playing: TabData[] = [];
+    const audible: TabData[] = [];
+    const paused: TabData[] = [];
+    const muted: TabData[] = [];
 
     for (const tab of tabsData.tabs) {
-      if (tab.mediaPlaybackState === "playing" && !playingTab) {
-        playingTab = tab;
-      }
-      if (tab.audible && !audibleTab) {
-        audibleTab = tab;
-      }
-      if (tab.mediaPlaybackState === "paused" && !pausedTab) {
-        pausedTab = tab;
-      }
-      if (tab.muted && !tab.audible && !mutedTab) {
-        mutedTab = tab;
+      // Skip the tab the user is currently viewing
+      if (tab.id === focusedTabId) continue;
+
+      if (tab.mediaPlaybackState === "playing") {
+        playing.push(tab);
+      } else if (tab.audible) {
+        audible.push(tab);
+      } else if (tab.mediaPlaybackState === "paused") {
+        paused.push(tab);
+      } else if (tab.muted) {
+        muted.push(tab);
       }
     }
 
-    // Prefer tab with "playing" mediaSession state, then audible, then paused, then muted
-    return playingTab ?? audibleTab ?? pausedTab ?? mutedTab ?? null;
-  }, [tabsData]);
-}
-
-/**
- * Returns all tabs that are currently producing audio, paused with metadata, or muted.
- */
-function useMediaTabCount(): number {
-  const { tabsData } = useTabs();
-
-  return useMemo(() => {
-    if (!tabsData?.tabs) return 0;
-    return tabsData.tabs.filter(
-      (tab) => tab.audible || tab.muted || tab.mediaPlaybackState === "playing" || tab.mediaPlaybackState === "paused"
-    ).length;
-  }, [tabsData]);
+    return [...playing, ...audible, ...paused, ...muted];
+  }, [tabsData, focusedTabId]);
 }
 
 // --- MediaControlButton --- //
@@ -86,160 +72,145 @@ function MediaControlButton({
   );
 }
 
-// --- GlobalMediaControls --- //
+// --- MediaCard --- //
 
-export const GlobalMediaControls = memo(function GlobalMediaControls() {
-  const mediaTab = usePrimaryMediaTab();
-  const mediaTabCount = useMediaTabCount();
+const MediaCard = memo(function MediaCard({ tab }: { tab: TabData }) {
   const [faviconError, setFaviconError] = useState(false);
+
+  // Reset favicon error when the tab's favicon changes
+  const [prevFavicon, setPrevFavicon] = useState(tab.faviconURL);
+  if (tab.faviconURL !== prevFavicon) {
+    setPrevFavicon(tab.faviconURL);
+    setFaviconError(false);
+  }
 
   const handlePlayPause = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (!mediaTab) return;
-      flow.tabs.mediaPlayPause(mediaTab.id);
+      flow.tabs.mediaPlayPause(tab.id);
     },
-    [mediaTab]
+    [tab.id]
   );
 
   const handlePrevTrack = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (!mediaTab) return;
-      flow.tabs.mediaPreviousTrack(mediaTab.id);
+      flow.tabs.mediaPreviousTrack(tab.id);
     },
-    [mediaTab]
+    [tab.id]
   );
 
   const handleNextTrack = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (!mediaTab) return;
-      flow.tabs.mediaNextTrack(mediaTab.id);
+      flow.tabs.mediaNextTrack(tab.id);
     },
-    [mediaTab]
+    [tab.id]
   );
 
   const handleToggleMute = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (!mediaTab) return;
-      flow.tabs.setTabMuted(mediaTab.id, !mediaTab.muted);
+      flow.tabs.setTabMuted(tab.id, !tab.muted);
     },
-    [mediaTab]
+    [tab.id, tab.muted]
   );
 
   const handleSwitchToTab = useCallback(() => {
-    if (!mediaTab) return;
-    flow.tabs.switchToTab(mediaTab.id);
-  }, [mediaTab]);
+    flow.tabs.switchToTab(tab.id);
+  }, [tab.id]);
 
-  // Determine display values
-  const displayTitle = useMemo(() => {
-    if (!mediaTab) return "";
-    // Use media metadata title if available, otherwise tab title
-    return mediaTab.mediaTitle || mediaTab.title;
-  }, [mediaTab]);
+  const displayTitle = tab.mediaTitle || tab.title;
+  const displayArtist = tab.mediaArtist || null;
+  const isPlaying = tab.mediaPlaybackState === "playing" || (tab.audible && !tab.muted);
 
-  const displayArtist = useMemo(() => {
-    if (!mediaTab) return null;
-    return mediaTab.mediaArtist || null;
-  }, [mediaTab]);
+  return (
+    <motion.div
+      key={tab.id}
+      initial={{ opacity: 0, height: 0, marginTop: 0 }}
+      animate={{ opacity: 1, height: "auto", marginTop: 8 }}
+      exit={{ opacity: 0, height: 0, marginTop: 0 }}
+      transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+      className="shrink-0 overflow-hidden"
+    >
+      <div
+        className={cn(
+          "w-full rounded-xl overflow-hidden",
+          "border border-black/10 dark:border-white/15",
+          "bg-black/5 dark:bg-white/10"
+        )}
+      >
+        {/* Top row: favicon + title */}
+        <div
+          className={cn(
+            "flex items-center gap-2 px-2.5 pt-2 pb-1",
+            "cursor-pointer",
+            "hover:bg-black/5 dark:hover:bg-white/5",
+            "transition-colors duration-100"
+          )}
+          onClick={handleSwitchToTab}
+        >
+          {/* Favicon */}
+          <div className="size-4 shrink-0">
+            {tab.faviconURL && !faviconError ? (
+              <img
+                src={craftActiveFaviconURL(tab.id, tab.faviconURL)}
+                alt=""
+                className="size-full rounded-sm object-contain overflow-hidden"
+                style={{ userSelect: "none", WebkitUserDrag: "none" } as React.CSSProperties}
+                onError={() => setFaviconError(true)}
+              />
+            ) : (
+              <div className="size-full bg-gray-300 dark:bg-gray-300/30 rounded-sm" />
+            )}
+          </div>
 
-  const isPlaying = mediaTab?.mediaPlaybackState === "playing" || (mediaTab?.audible && !mediaTab?.muted);
+          {/* Title + Artist */}
+          <div className="flex-1 min-w-0">
+            <div className="truncate text-xs font-medium text-black/90 dark:text-white/90">{displayTitle}</div>
+            {displayArtist && (
+              <div className="truncate text-[10px] text-black/50 dark:text-white/50">{displayArtist}</div>
+            )}
+          </div>
+        </div>
 
-  // Reset favicon error when the media tab changes
-  const currentTabId = mediaTab?.id;
-  const [prevTabId, setPrevTabId] = useState<number | undefined>(undefined);
-  if (currentTabId !== prevTabId) {
-    setPrevTabId(currentTabId);
-    setFaviconError(false);
-  }
+        {/* Bottom row: playback controls */}
+        <div className="flex items-center justify-center gap-1 px-2 pb-2 pt-0.5">
+          <MediaControlButton icon={SkipBack} onClick={handlePrevTrack} label="Previous track" size="size-3" />
+          <MediaControlButton
+            icon={isPlaying ? Pause : Play}
+            onClick={handlePlayPause}
+            label={isPlaying ? "Pause" : "Play"}
+            size="size-4"
+          />
+          <MediaControlButton icon={SkipForward} onClick={handleNextTrack} label="Next track" size="size-3" />
+
+          {/* Spacer */}
+          <div className="flex-1" />
+
+          {/* Mute toggle */}
+          <MediaControlButton
+            icon={tab.muted ? VolumeX : Volume2}
+            onClick={handleToggleMute}
+            label={tab.muted ? "Unmute" : "Mute"}
+            size="size-3.5"
+          />
+        </div>
+      </div>
+    </motion.div>
+  );
+});
+
+// --- GlobalMediaControls --- //
+
+export const GlobalMediaControls = memo(function GlobalMediaControls() {
+  const mediaTabs = useMediaTabs();
 
   return (
     <AnimatePresence>
-      {mediaTab && (
-        <motion.div
-          key="global-media-controls"
-          initial={{ opacity: 0, height: 0, marginTop: 0 }}
-          animate={{ opacity: 1, height: "auto", marginTop: 8 }}
-          exit={{ opacity: 0, height: 0, marginTop: 0 }}
-          transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
-          className="shrink-0 overflow-hidden"
-        >
-          <div
-            className={cn(
-              "w-full rounded-xl overflow-hidden",
-              "border border-black/10 dark:border-white/15",
-              "bg-black/5 dark:bg-white/10"
-            )}
-          >
-            {/* Top row: favicon + title + mute button */}
-            <div
-              className={cn(
-                "flex items-center gap-2 px-2.5 pt-2 pb-1",
-                "cursor-pointer",
-                "hover:bg-black/5 dark:hover:bg-white/5",
-                "transition-colors duration-100"
-              )}
-              onClick={handleSwitchToTab}
-            >
-              {/* Favicon */}
-              <div className="size-4 shrink-0">
-                {mediaTab.faviconURL && !faviconError ? (
-                  <img
-                    src={craftActiveFaviconURL(mediaTab.id, mediaTab.faviconURL)}
-                    alt=""
-                    className="size-full rounded-sm object-contain overflow-hidden"
-                    style={{ userSelect: "none", WebkitUserDrag: "none" } as React.CSSProperties}
-                    onError={() => setFaviconError(true)}
-                  />
-                ) : (
-                  <div className="size-full bg-gray-300 dark:bg-gray-300/30 rounded-sm" />
-                )}
-              </div>
-
-              {/* Title + Artist */}
-              <div className="flex-1 min-w-0">
-                <div className="truncate text-xs font-medium text-black/90 dark:text-white/90">{displayTitle}</div>
-                {displayArtist && (
-                  <div className="truncate text-[10px] text-black/50 dark:text-white/50">{displayArtist}</div>
-                )}
-              </div>
-
-              {/* Tab count badge */}
-              {mediaTabCount > 1 && (
-                <span className="shrink-0 text-[10px] font-medium text-black/40 dark:text-white/40">
-                  +{mediaTabCount - 1}
-                </span>
-              )}
-            </div>
-
-            {/* Bottom row: playback controls */}
-            <div className="flex items-center justify-center gap-1 px-2 pb-2 pt-0.5">
-              <MediaControlButton icon={SkipBack} onClick={handlePrevTrack} label="Previous track" size="size-3" />
-              <MediaControlButton
-                icon={isPlaying ? Pause : Play}
-                onClick={handlePlayPause}
-                label={isPlaying ? "Pause" : "Play"}
-                size="size-4"
-              />
-              <MediaControlButton icon={SkipForward} onClick={handleNextTrack} label="Next track" size="size-3" />
-
-              {/* Spacer */}
-              <div className="flex-1" />
-
-              {/* Mute toggle */}
-              <MediaControlButton
-                icon={mediaTab.muted ? VolumeX : Volume2}
-                onClick={handleToggleMute}
-                label={mediaTab.muted ? "Unmute" : "Mute"}
-                size="size-3.5"
-              />
-            </div>
-          </div>
-        </motion.div>
-      )}
+      {mediaTabs.map((tab) => (
+        <MediaCard key={tab.id} tab={tab} />
+      ))}
     </AnimatePresence>
   );
 });

--- a/src/renderer/src/components/browser-ui/browser-sidebar/inner.tsx
+++ b/src/renderer/src/components/browser-ui/browser-sidebar/inner.tsx
@@ -14,6 +14,7 @@ import { SpaceSwitcher } from "@/components/browser-ui/browser-sidebar/_componen
 import { SpacePagesCarousel } from "@/components/browser-ui/browser-sidebar/_components/space-pages-carousel";
 import { BrowserActionList } from "@/components/browser-ui/browser-sidebar/_components/browser-action-list";
 import { UpdateBanner } from "@/components/browser-ui/browser-sidebar/_components/update-banner";
+import { GlobalMediaControls } from "@/components/browser-ui/browser-sidebar/_components/global-media-controls";
 
 function SidebarIcon({ className }: { className?: string }) {
   return (
@@ -65,6 +66,8 @@ export function SidebarInner({ direction, variant }: { direction: AttachedDirect
       </div>
       {/* Update Banner */}
       <UpdateBanner />
+      {/* Global Media Controls */}
+      <GlobalMediaControls />
       {/* Bottom Section */}
       <div className="shrink-0 flex items-center justify-between h-4 my-2">
         <Button

--- a/src/shared/flow/interfaces/browser/tabs.ts
+++ b/src/shared/flow/interfaces/browser/tabs.ts
@@ -103,4 +103,27 @@ export interface FlowTabsAPI {
    * @returns Whether the operation was successful
    */
   clearRecentlyClosed: () => Promise<boolean>;
+
+  // --- Media Controls ---
+
+  /**
+   * Toggle play/pause on a tab's media
+   * @param tabId The id of the tab to control
+   * @returns Whether the action was successful
+   */
+  mediaPlayPause: (tabId: number) => Promise<boolean>;
+
+  /**
+   * Skip to the next track on a tab's media
+   * @param tabId The id of the tab to control
+   * @returns Whether the action was successful
+   */
+  mediaNextTrack: (tabId: number) => Promise<boolean>;
+
+  /**
+   * Skip to the previous track on a tab's media
+   * @param tabId The id of the tab to control
+   * @returns Whether the action was successful
+   */
+  mediaPreviousTrack: (tabId: number) => Promise<boolean>;
 }

--- a/src/shared/types/tabs.ts
+++ b/src/shared/types/tabs.ts
@@ -71,6 +71,12 @@ export type TabData = Omit<PersistedTabData, "navHistory" | "navHistoryIndex"> &
   fullScreen: boolean;
   isPictureInPicture: boolean;
   asleep: boolean;
+
+  // Media metadata (from page's navigator.mediaSession, runtime only)
+  mediaTitle: string | null;
+  mediaArtist: string | null;
+  mediaArtwork: string | null;
+  mediaPlaybackState: "playing" | "paused" | "none";
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds a **Global Media Controls** widget to the sidebar that displays now-playing info (title, artist, artwork) extracted from web pages and provides play/pause, skip track, and mute controls without switching tabs
- Uses a **preload-based push approach** (MutationObserver + `contextBridge.executeInMainWorld()`) to watch `navigator.mediaSession` metadata changes and send them to the main process via IPC — no polling from renderer
- Each media tab gets its own card in the sidebar; cards for the currently focused tab are hidden to avoid redundancy

## Changes

| Area | Files | What |
|------|-------|------|
| Design | `design/GLOBAL_MEDIA_CONTROLS.md` | Feature design document (source of truth) |
| Shared types | `tabs.ts`, `interfaces/browser/tabs.ts` | Added `mediaTitle`, `mediaArtist`, `mediaArtwork`, `mediaPlaybackState` to `TabData`; added `mediaPlayPause`/`mediaNextTrack`/`mediaPreviousTrack` to `FlowTabsAPI` |
| Main process | `tab.ts`, `tabs.ts` (IPC), `serialization.ts` | Media metadata properties on `Tab` class, IPC handlers for control commands + metadata updates, serialization of new fields |
| Preload | `index.ts` | `setupMediaSessionWatcher()` with MutationObserver + setTimeout throttling + 3s fallback poll + play/pause event listeners; monkey-patches `navigator.mediaSession.setActionHandler()` to capture handler refs for skip track support; media control bridge methods |
| Renderer | `global-media-controls.tsx` (new), `inner.tsx` | `GlobalMediaControls` component with per-tab `MediaCard` components, AnimatePresence animations, active tab filtering |

## Key Design Decisions

- **Preload push (not polling)**: MediaSession metadata is observed via MutationObserver + play/pause event listeners in the page context and pushed to main process via IPC, rather than polling with `executeJavaScript`
- **Action handler monkey-patching**: `navigator.mediaSession.setActionHandler()` is monkey-patched in the preload to capture handler references, allowing skip track/play/pause to call the page's actual handlers directly instead of dispatching fake keyboard events
- **setTimeout over rAF**: Uses `setTimeout` for debouncing because Chromium completely suspends `requestAnimationFrame` in background tabs (the exact use case for media controls)
- **Media element as ground truth**: Playback state is derived from `<video>`/`<audio>` element's `.paused` property, not `navigator.mediaSession.playbackState` (many sites never update the latter)
- **Play/pause events sent immediately**: Not debounced, for instant UI response when toggling playback

## Notes

- Phase 3 (hardware media keys) was **cancelled** — Chromium/OS handles this natively
- Known TODO: MediaSession watcher currently only monitors the main frame, not iframes (e.g. YouTube embeds)