### PR TITLE
feat: add native prompt support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
         "node-abi": "^4.28.0",
         "nuqs": "^2.8.9",
         "prettier": "^3.8.1",
-        "radix-ui": "^1.4.2",
+        "radix-ui": "^1.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-use": "^17.6.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "node-abi": "^4.28.0",
     "nuqs": "^2.8.9",
     "prettier": "^3.8.1",
-    "radix-ui": "^1.4.2",
+    "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-use": "^17.6.0",

--- a/src/main/ipc/browser/prompts.ts
+++ b/src/main/ipc/browser/prompts.ts
@@ -36,3 +36,11 @@ ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string
     event.returnValue = null;
   }
 });
+
+ipcMain.on("prompts:confirm", async (event, message: string) => {
+  // TODO: Implement confirm prompt
+});
+
+ipcMain.on("prompts:alert", async (event, message: string) => {
+  // TODO: Implement alert prompt
+});

--- a/src/main/ipc/browser/prompts.ts
+++ b/src/main/ipc/browser/prompts.ts
@@ -1,0 +1,6 @@
+import { ipcMain } from "electron";
+
+ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string) => {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  event.returnValue = "hi";
+});

--- a/src/main/ipc/browser/prompts.ts
+++ b/src/main/ipc/browser/prompts.ts
@@ -7,20 +7,27 @@ ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string
   const { promise, resolve } = Promise.withResolvers<PromptResult<string | null>>();
 
   const webContents = event.sender;
+  const webFrame = event.senderFrame;
   const tabId = tabsController.getTabByWebContents(webContents)?.id ?? null;
-  if (!tabId) {
+  if (!tabId || !webFrame) {
     // not a tab, return null
     event.returnValue = null;
     return;
   }
 
-  queuePrompt({
-    type: "prompt",
-    message,
-    defaultValue,
-    resolver: resolve,
-    tabId
-  });
+  queuePrompt(
+    {
+      type: "prompt",
+      message,
+      defaultValue,
+      promise,
+      resolver: resolve,
+      tabId
+    },
+    {
+      cancelOnWebFrameDetach: { webContents, webFrame }
+    }
+  );
 
   const result = await promise;
   if (result.success) {

--- a/src/main/ipc/browser/prompts.ts
+++ b/src/main/ipc/browser/prompts.ts
@@ -1,6 +1,31 @@
+import { tabsController } from "@/controllers/tabs-controller";
+import { queuePrompt } from "@/modules/prompts";
 import { ipcMain } from "electron";
+import { PromptResult } from "~/types/prompts";
 
 ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string) => {
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  event.returnValue = "hi";
+  const { promise, resolve } = Promise.withResolvers<PromptResult<string | null>>();
+
+  const webContents = event.sender;
+  const tabId = tabsController.getTabByWebContents(webContents)?.id ?? null;
+  if (!tabId) {
+    // not a tab, return null
+    event.returnValue = null;
+    return;
+  }
+
+  queuePrompt({
+    type: "prompt",
+    message,
+    defaultValue,
+    resolver: resolve,
+    tabId
+  });
+
+  const result = await promise;
+  if (result.success) {
+    event.returnValue = result.result;
+  } else {
+    event.returnValue = null;
+  }
 });

--- a/src/main/ipc/browser/prompts/browser.ts
+++ b/src/main/ipc/browser/prompts/browser.ts
@@ -23,6 +23,6 @@ ipcMain.handle("prompts:get-active-prompts", () => {
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-ipcMain.on("prompts:confirm", (_event, promptId: string, result: any) => {
+ipcMain.on("prompts:confirm-prompt", (_event, promptId: string, result: any) => {
   promptCompleted(promptId, result);
 });

--- a/src/main/ipc/browser/prompts/browser.ts
+++ b/src/main/ipc/browser/prompts/browser.ts
@@ -1,5 +1,5 @@
 import { sendMessageToListeners } from "@/ipc/listeners-manager";
-import { getActivePromptsForRenderer, promptCompleted } from "@/modules/prompts";
+import { getActivePromptsForRenderer, promptCompleted, suppressPrompt } from "@/modules/prompts";
 import { ipcMain } from "electron";
 
 let activePromptsChangedImmediate: NodeJS.Immediate | null = null;
@@ -25,4 +25,8 @@ ipcMain.handle("prompts:get-active-prompts", () => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ipcMain.on("prompts:confirm-prompt", (_event, promptId: string, result: any) => {
   promptCompleted(promptId, result);
+});
+
+ipcMain.on("prompts:suppress-prompt", (_event, suppressionKey: string) => {
+  suppressPrompt(suppressionKey);
 });

--- a/src/main/ipc/browser/prompts/browser.ts
+++ b/src/main/ipc/browser/prompts/browser.ts
@@ -1,5 +1,5 @@
 import { sendMessageToListeners } from "@/ipc/listeners-manager";
-import { getActivePromptsForRenderer, promptCompleted, suppressPrompt } from "@/modules/prompts";
+import { getActivePromptsForRenderer, promptCompleted } from "@/modules/prompts";
 import { ipcMain } from "electron";
 
 let activePromptsChangedImmediate: NodeJS.Immediate | null = null;
@@ -23,10 +23,6 @@ ipcMain.handle("prompts:get-active-prompts", () => {
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-ipcMain.on("prompts:confirm-prompt", (_event, promptId: string, result: any) => {
-  promptCompleted(promptId, result);
-});
-
-ipcMain.on("prompts:suppress-prompt", (_event, suppressionKey: string) => {
-  suppressPrompt(suppressionKey);
+ipcMain.on("prompts:confirm-prompt", (_event, promptId: string, result: any, suppress: boolean) => {
+  promptCompleted(promptId, result, suppress);
 });

--- a/src/main/ipc/browser/prompts/browser.ts
+++ b/src/main/ipc/browser/prompts/browser.ts
@@ -13,8 +13,8 @@ export function activePromptsChanged() {
   if (activePromptsChangedImmediate) return;
 
   activePromptsChangedImmediate = setImmediate(() => {
-    sendMessageToListeners("prompts:on-active-prompts-changed", getActivePromptsForRenderer());
     cleanupActivePromptsImmediate();
+    sendMessageToListeners("prompts:on-active-prompts-changed", getActivePromptsForRenderer());
   });
 }
 

--- a/src/main/ipc/browser/prompts/browser.ts
+++ b/src/main/ipc/browser/prompts/browser.ts
@@ -1,0 +1,23 @@
+import { sendMessageToListeners } from "@/ipc/listeners-manager";
+import { getActivePromptsForRenderer } from "@/modules/prompts";
+import { ipcMain } from "electron";
+
+let activePromptsChangedImmediate: NodeJS.Immediate | null = null;
+function cleanupActivePromptsImmediate() {
+  if (activePromptsChangedImmediate) {
+    clearImmediate(activePromptsChangedImmediate);
+    activePromptsChangedImmediate = null;
+  }
+}
+export function activePromptsChanged() {
+  if (activePromptsChangedImmediate) return;
+
+  activePromptsChangedImmediate = setImmediate(() => {
+    sendMessageToListeners("prompts:on-active-prompts-changed", getActivePromptsForRenderer());
+    cleanupActivePromptsImmediate();
+  });
+}
+
+ipcMain.handle("prompts:get-active-prompts", () => {
+  return getActivePromptsForRenderer();
+});

--- a/src/main/ipc/browser/prompts/browser.ts
+++ b/src/main/ipc/browser/prompts/browser.ts
@@ -1,5 +1,5 @@
 import { sendMessageToListeners } from "@/ipc/listeners-manager";
-import { getActivePromptsForRenderer } from "@/modules/prompts";
+import { getActivePromptsForRenderer, promptCompleted } from "@/modules/prompts";
 import { ipcMain } from "electron";
 
 let activePromptsChangedImmediate: NodeJS.Immediate | null = null;
@@ -20,4 +20,9 @@ export function activePromptsChanged() {
 
 ipcMain.handle("prompts:get-active-prompts", () => {
   return getActivePromptsForRenderer();
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ipcMain.on("prompts:confirm", (_event, promptId: string, result: any) => {
+  promptCompleted(promptId, result);
 });

--- a/src/main/ipc/browser/prompts/index.ts
+++ b/src/main/ipc/browser/prompts/index.ts
@@ -1,0 +1,5 @@
+// Page IPCs
+import "./page";
+
+// Browser IPCs
+import "./browser";

--- a/src/main/ipc/browser/prompts/page.ts
+++ b/src/main/ipc/browser/prompts/page.ts
@@ -1,10 +1,20 @@
 import { tabsController } from "@/controllers/tabs-controller";
 import { queuePrompt } from "@/modules/prompts";
 import { ipcMain } from "electron";
-import { PromptResult } from "~/types/prompts";
+import type { PromptResult, PromptState } from "~/types/prompts";
 
-ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string) => {
-  const { promise, resolve } = Promise.withResolvers<PromptResult<string | null>>();
+type GeneratePromptState<ResultType> = (
+  promise: Promise<PromptResult<ResultType>>,
+  resolve: (value: PromptResult<ResultType>) => void,
+  tabId: number
+) => PromptState;
+
+async function processPromptRequest<ResultType>(
+  event: Electron.IpcMainEvent,
+  generatePromptState: GeneratePromptState<ResultType>,
+  failedValue: ResultType
+) {
+  const { promise, resolve } = Promise.withResolvers<PromptResult<ResultType>>();
 
   const webContents = event.sender;
   const webFrame = event.senderFrame;
@@ -12,12 +22,26 @@ ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string
   if (!tabId || !webFrame) {
     // not a tab, return null
     event.returnValue = null;
-    return;
+    return false;
   }
 
-  queuePrompt(
-    {
-      // Will be overridden by the queuePrompt function
+  queuePrompt(generatePromptState(promise, resolve, tabId), {
+    cancelOnWebFrameDetach: { webContents, webFrame }
+  });
+
+  const result = await promise;
+  if (result.success) {
+    event.returnValue = result.result;
+  } else {
+    event.returnValue = failedValue;
+  }
+  return true;
+}
+
+ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string) => {
+  const generatePromptState: GeneratePromptState<string | null> = (promise, resolve, tabId) => {
+    return {
+      // id will be overridden by the queuePrompt function
       id: "",
       type: "prompt",
       message,
@@ -25,26 +49,37 @@ ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string
       promise,
       resolver: resolve,
       tabId
-    },
-    {
-      cancelOnWebFrameDetach: { webContents, webFrame }
-    }
-  );
-
-  const result = await promise;
-  if (result.success) {
-    event.returnValue = result.result;
-  } else {
-    event.returnValue = null;
-  }
+    };
+  };
+  return processPromptRequest(event, generatePromptState, null);
 });
 
-/**
 ipcMain.on("prompts:confirm", async (event, message: string) => {
-  // TODO: Implement confirm prompt
+  const generatePromptState: GeneratePromptState<boolean> = (promise, resolve, tabId) => {
+    return {
+      // id will be overridden by the queuePrompt function
+      id: "",
+      type: "confirm",
+      message,
+      promise,
+      resolver: resolve,
+      tabId
+    };
+  };
+  return processPromptRequest(event, generatePromptState, false);
 });
 
 ipcMain.on("prompts:alert", async (event, message: string) => {
-  // TODO: Implement alert prompt
+  const generatePromptState: GeneratePromptState<void> = (promise, resolve, tabId) => {
+    return {
+      // id will be overridden by the queuePrompt function
+      id: "",
+      type: "alert",
+      message,
+      promise,
+      resolver: resolve,
+      tabId
+    };
+  };
+  return processPromptRequest(event, generatePromptState, undefined);
 });
-**/

--- a/src/main/ipc/browser/prompts/page.ts
+++ b/src/main/ipc/browser/prompts/page.ts
@@ -21,7 +21,7 @@ async function processPromptRequest<ResultType>(
   const tabId = tabsController.getTabByWebContents(webContents)?.id ?? null;
   if (!tabId || !webFrame) {
     // not a tab, return null
-    event.returnValue = null;
+    event.returnValue = failedValue;
     return false;
   }
 

--- a/src/main/ipc/browser/prompts/page.ts
+++ b/src/main/ipc/browser/prompts/page.ts
@@ -2,12 +2,18 @@ import { tabsController } from "@/controllers/tabs-controller";
 import { queuePrompt } from "@/modules/prompts";
 import { ipcMain } from "electron";
 import type { PromptResult, PromptState } from "~/types/prompts";
+import { DistributiveOmit } from "~/types/utils";
+import { getOriginFromURL } from "~/utility";
+
+function generateSuppressionKey(tabId: number, url: string) {
+  return `${tabId}-${getOriginFromURL(url)}`;
+}
 
 type GeneratePromptState<ResultType> = (
   promise: Promise<PromptResult<ResultType>>,
   resolve: (value: PromptResult<ResultType>) => void,
   tabId: number
-) => PromptState;
+) => DistributiveOmit<PromptState, "suppressionKey" | "originUrl">;
 
 async function processPromptRequest<ResultType>(
   event: Electron.IpcMainEvent,
@@ -25,7 +31,17 @@ async function processPromptRequest<ResultType>(
     return false;
   }
 
-  queuePrompt(generatePromptState(promise, resolve, tabId), {
+  const generatedPromptState = generatePromptState(promise, resolve, tabId);
+
+  const originUrl = webFrame.url;
+  const suppressionKey = generateSuppressionKey(tabId, originUrl);
+  const promptState = {
+    ...generatedPromptState,
+    suppressionKey,
+    originUrl
+  };
+
+  queuePrompt(promptState, {
     cancelOnWebFrameDetach: { webContents, webFrame }
   });
 

--- a/src/main/ipc/browser/prompts/page.ts
+++ b/src/main/ipc/browser/prompts/page.ts
@@ -17,6 +17,8 @@ ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string
 
   queuePrompt(
     {
+      // Will be overridden by the queuePrompt function
+      id: "",
       type: "prompt",
       message,
       defaultValue,
@@ -37,6 +39,7 @@ ipcMain.on("prompts:prompt", async (event, message: string, defaultValue: string
   }
 });
 
+/**
 ipcMain.on("prompts:confirm", async (event, message: string) => {
   // TODO: Implement confirm prompt
 });
@@ -44,3 +47,4 @@ ipcMain.on("prompts:confirm", async (event, message: string) => {
 ipcMain.on("prompts:alert", async (event, message: string) => {
   // TODO: Implement alert prompt
 });
+**/

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -16,6 +16,7 @@ import "@/ipc/browser/interface";
 import "@/ipc/browser/find-in-page";
 import "@/ipc/window/omnibox";
 import "@/ipc/app/new-tab";
+import "@/ipc/browser/prompts";
 
 // Session APIs
 import "@/ipc/session/profiles";

--- a/src/main/modules/prompts.ts
+++ b/src/main/modules/prompts.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { generateID } from "@/modules/utils";
+import type { PromptState } from "~/types/prompts";
+
+// Prompt Queue Logic //
+const promptQueue: PromptState[] = [];
+const activePrompts: PromptState[] = [];
+
+function removePromptById(prompts: PromptState[], id: string) {
+  const index = prompts.findIndex((prompt) => prompt.id === id);
+  if (index === -1) return null;
+
+  const [prompt] = prompts.splice(index, 1);
+  return prompt;
+}
+
+function processPromptQueue() {
+  for (let i = 0; i < promptQueue.length; ) {
+    const queuedPrompt = promptQueue[i];
+    const tabAlreadyHasActivePrompt = activePrompts.some((prompt) => prompt.tabId === queuedPrompt.tabId);
+
+    if (tabAlreadyHasActivePrompt) {
+      i += 1;
+      continue;
+    }
+
+    activePrompts.push(queuedPrompt);
+    promptQueue.splice(i, 1);
+  }
+}
+
+export function queuePrompt(prompt: Omit<PromptState, "id">) {
+  const id = generateID();
+  promptQueue.push({
+    id,
+    ...prompt
+  });
+
+  processPromptQueue();
+
+  return id;
+}
+
+export function cancelPrompt(id: string) {
+  const queuedPrompt = removePromptById(promptQueue, id);
+  if (queuedPrompt) {
+    queuedPrompt.resolver({ success: false });
+    return;
+  }
+
+  const activePrompt = removePromptById(activePrompts, id);
+  if (!activePrompt) return;
+
+  activePrompt.resolver({ success: false });
+  processPromptQueue();
+}
+
+export function promptCompleted(promptId: string, result: any) {
+  const activePrompt = removePromptById(activePrompts, promptId);
+  if (!activePrompt) return false;
+
+  activePrompt.resolver({
+    success: true,
+    result
+  });
+
+  processPromptQueue();
+  return true;
+}

--- a/src/main/modules/prompts.ts
+++ b/src/main/modules/prompts.ts
@@ -74,9 +74,14 @@ export function cancelPrompt(id: string) {
   processPromptQueue();
 }
 
-export function promptCompleted(promptId: string, result: any) {
+export function promptCompleted(promptId: string, result: any, suppress: boolean) {
   const activePrompt = removePromptById(activePrompts, promptId);
   if (!activePrompt) return false;
+
+  if (suppress && activePrompt.suppressionKey) {
+    suppressPrompt(activePrompt.suppressionKey);
+  }
+
   activePromptsChanged();
 
   switch (activePrompt.type) {

--- a/src/main/modules/prompts.ts
+++ b/src/main/modules/prompts.ts
@@ -105,6 +105,5 @@ export function getActivePromptsForRenderer(): ActivePrompt[] {
     void resolver;
     return rest;
   });
-  console.log("activePromptsForRenderer", activePromptsForRenderer);
   return activePromptsForRenderer;
 }

--- a/src/main/modules/prompts.ts
+++ b/src/main/modules/prompts.ts
@@ -4,6 +4,8 @@ import { activePromptsChanged } from "@/ipc/browser/prompts/browser";
 import { generateID, onWebFrameDestroyed } from "@/modules/utils";
 import type { ActivePrompt, PromptState } from "~/types/prompts";
 
+const suppressedKeys = new Set<string>();
+
 // Prompt Queue Logic //
 const promptQueue: PromptState[] = [];
 const activePrompts: PromptState[] = [];
@@ -29,6 +31,11 @@ function processPromptQueue() {
     activePrompts.push(queuedPrompt);
     promptQueue.splice(i, 1);
     activePromptsChanged();
+
+    // Prompt is suppressed, cancel it
+    if (queuedPrompt.suppressionKey && suppressedKeys.has(queuedPrompt.suppressionKey)) {
+      cancelPrompt(queuedPrompt.id);
+    }
   }
 }
 
@@ -106,4 +113,10 @@ export function getActivePromptsForRenderer(): ActivePrompt[] {
     return rest;
   });
   return activePromptsForRenderer;
+}
+
+export function suppressPrompt(suppressionKey: string) {
+  if (suppressedKeys.has(suppressionKey)) return false;
+  suppressedKeys.add(suppressionKey);
+  return true;
 }

--- a/src/main/modules/prompts.ts
+++ b/src/main/modules/prompts.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { generateID } from "@/modules/utils";
+import { generateID, onWebFrameDestroyed } from "@/modules/utils";
 import type { PromptState } from "~/types/prompts";
 
 // Prompt Queue Logic //
@@ -30,12 +30,23 @@ function processPromptQueue() {
   }
 }
 
-export function queuePrompt(prompt: Omit<PromptState, "id">) {
+interface QueuePromptOptions {
+  cancelOnWebFrameDetach?: { webContents: Electron.WebContents; webFrame: Electron.WebFrameMain };
+}
+export function queuePrompt(prompt: Omit<PromptState, "id">, options: QueuePromptOptions = {}) {
   const id = generateID();
   promptQueue.push({
     id,
     ...prompt
   });
+
+  if (options.cancelOnWebFrameDetach) {
+    const { webContents, webFrame } = options.cancelOnWebFrameDetach;
+    const cleanup = onWebFrameDestroyed(webContents, webFrame, () => {
+      cancelPrompt(id);
+    });
+    prompt.promise.finally(cleanup);
+  }
 
   processPromptQueue();
 

--- a/src/main/modules/prompts.ts
+++ b/src/main/modules/prompts.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { activePromptsChanged } from "@/ipc/browser/prompts/browser";
 import { generateID, onWebFrameDestroyed } from "@/modules/utils";
-import type { PromptState } from "~/types/prompts";
+import type { ActivePrompt, PromptState } from "~/types/prompts";
 
 // Prompt Queue Logic //
 const promptQueue: PromptState[] = [];
@@ -27,18 +28,16 @@ function processPromptQueue() {
 
     activePrompts.push(queuedPrompt);
     promptQueue.splice(i, 1);
+    activePromptsChanged();
   }
 }
 
 interface QueuePromptOptions {
   cancelOnWebFrameDetach?: { webContents: Electron.WebContents; webFrame: Electron.WebFrameMain };
 }
-export function queuePrompt(prompt: Omit<PromptState, "id">, options: QueuePromptOptions = {}) {
+export function queuePrompt(prompt: PromptState, options: QueuePromptOptions = {}) {
   const id = generateID();
-  promptQueue.push({
-    id,
-    ...prompt
-  });
+  promptQueue.push({ ...prompt, id });
 
   if (options.cancelOnWebFrameDetach) {
     const { webContents, webFrame } = options.cancelOnWebFrameDetach;
@@ -62,6 +61,7 @@ export function cancelPrompt(id: string) {
 
   const activePrompt = removePromptById(activePrompts, id);
   if (!activePrompt) return;
+  activePromptsChanged();
 
   activePrompt.resolver({ success: false });
   processPromptQueue();
@@ -70,12 +70,41 @@ export function cancelPrompt(id: string) {
 export function promptCompleted(promptId: string, result: any) {
   const activePrompt = removePromptById(activePrompts, promptId);
   if (!activePrompt) return false;
+  activePromptsChanged();
 
-  activePrompt.resolver({
-    success: true,
-    result
-  });
+  switch (activePrompt.type) {
+    case "prompt":
+      activePrompt.resolver({
+        success: true,
+        result
+      });
+      break;
+    case "confirm":
+      activePrompt.resolver({
+        success: true,
+        result
+      });
+      break;
+    case "alert":
+      activePrompt.resolver({
+        success: true,
+        result
+      });
+      break;
+  }
 
   processPromptQueue();
   return true;
+}
+
+// Flow UI Communication //
+export function getActivePromptsForRenderer(): ActivePrompt[] {
+  const activePromptsForRenderer = activePrompts.map((prompt) => {
+    const { promise, resolver, ...rest } = prompt;
+    void promise;
+    void resolver;
+    return rest;
+  });
+  console.log("activePromptsForRenderer", activePromptsForRenderer);
+  return activePromptsForRenderer;
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,6 +5,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { injectBrowserAction } from "electron-chrome-extensions/browser-action";
 import { tryPatchPasskeys } from "./webauthn";
+import { tryPatchPrompts } from "./prompts";
 
 // TYPE IMPORTS //
 import type { ProfileData } from "@/controllers/profiles-controller";
@@ -99,8 +100,9 @@ if (hasPermission("browser")) {
   injectBrowserAction();
 }
 
-// PASSKEYS PATCH //
+// API PATCHES //
 tryPatchPasskeys();
+tryPatchPrompts();
 
 // INTERNAL FUNCTIONS //
 function getOSFromPlatform(platform: NodeJS.Platform) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -659,7 +659,7 @@ const promptsAPI: FlowPromptsAPI = {
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   confirmPrompt: (promptId: string, result: any) => {
-    return ipcRenderer.send("prompts:confirm", promptId, result);
+    return ipcRenderer.send("prompts:confirm-prompt", promptId, result);
   }
 };
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -656,6 +656,10 @@ const promptsAPI: FlowPromptsAPI = {
   },
   onActivePromptsChanged: (callback: (prompts: ActivePrompt[]) => void) => {
     return listenOnIPCChannel("prompts:on-active-prompts-changed", callback);
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  confirmPrompt: (promptId: string, result: any) => {
+    return ipcRenderer.send("prompts:confirm", promptId, result);
   }
 };
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -43,6 +43,8 @@ import { FlowFindInPageAPI, FindInPageResult } from "~/flow/interfaces/browser/f
 import { FlowHistoryAPI } from "~/flow/interfaces/browser/history";
 import { FlowPasskeyAPI } from "~/flow/interfaces/browser/passkey";
 import type { ConditionalPasskeyRequest, PasskeyCredential } from "~/types/passkey";
+import { FlowPromptsAPI } from "~/flow/interfaces/browser/prompts";
+import type { ActivePrompt } from "~/types/prompts";
 
 // const isIFrame = !process.isMainFrame;
 
@@ -647,6 +649,16 @@ const findInPageAPI: FlowFindInPageAPI = {
   }
 };
 
+// PROMPTS API //
+const promptsAPI: FlowPromptsAPI = {
+  getActivePrompts: async () => {
+    return ipcRenderer.invoke("prompts:get-active-prompts");
+  },
+  onActivePromptsChanged: (callback: (prompts: ActivePrompt[]) => void) => {
+    return listenOnIPCChannel("prompts:on-active-prompts-changed", callback);
+  }
+};
+
 // SETTINGS API //
 const settingsAPI: FlowSettingsAPI = {
   getSetting: async (settingId: string) => {
@@ -790,6 +802,7 @@ const flowAPI: typeof flow = {
   omnibox: wrapAPI(omniboxAPI, "browser"),
   newTab: wrapAPI(newTabAPI, "browser"),
   findInPage: wrapAPI(findInPageAPI, "browser"),
+  prompts: wrapAPI(promptsAPI, "browser"),
 
   // Session APIs
   profiles: wrapAPI(profilesAPI, "session", {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -660,6 +660,9 @@ const promptsAPI: FlowPromptsAPI = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   confirmPrompt: (promptId: string, result: any) => {
     return ipcRenderer.send("prompts:confirm-prompt", promptId, result);
+  },
+  suppressPrompt: (suppressionKey: string) => {
+    return ipcRenderer.send("prompts:suppress-prompt", suppressionKey);
   }
 };
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -658,11 +658,8 @@ const promptsAPI: FlowPromptsAPI = {
     return listenOnIPCChannel("prompts:on-active-prompts-changed", callback);
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  confirmPrompt: (promptId: string, result: any) => {
-    return ipcRenderer.send("prompts:confirm-prompt", promptId, result);
-  },
-  suppressPrompt: (suppressionKey: string) => {
-    return ipcRenderer.send("prompts:suppress-prompt", suppressionKey);
+  confirmPrompt: (promptId: string, result: any, suppress: boolean) => {
+    return ipcRenderer.send("prompts:confirm-prompt", promptId, result, suppress);
   }
 };
 

--- a/src/preload/prompts.ts
+++ b/src/preload/prompts.ts
@@ -10,7 +10,7 @@ function normalizeNewlines(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-const MAX_DIALOG_STRING_LENGTH = 100;
+const MAX_DIALOG_STRING_LENGTH = 2000;
 /**
  * Optionally truncates a simple dialog string.
  * Per the HTML spec, no UI should be provided to display the elided portion,

--- a/src/preload/prompts.ts
+++ b/src/preload/prompts.ts
@@ -32,6 +32,16 @@ export function tryPatchPrompts() {
       const message = optionallyTruncate(normalizeNewlines(String(sourceMessage)));
       const defaultValue = optionallyTruncate(String(sourceDefaultValue));
       return ipcRenderer.sendSync("prompts:prompt", message, defaultValue) as string | null;
+    },
+
+    confirm: (sourceMessage: string) => {
+      const message = optionallyTruncate(normalizeNewlines(String(sourceMessage)));
+      return ipcRenderer.sendSync("prompts:confirm", message) as boolean;
+    },
+
+    alert: (sourceMessage: string) => {
+      const message = optionallyTruncate(normalizeNewlines(String(sourceMessage)));
+      return ipcRenderer.sendSync("prompts:alert", message) as void;
     }
   };
   contextBridge.exposeInMainWorld("electronPrompts", electronPromptsContainer);
@@ -41,19 +51,22 @@ export function tryPatchPrompts() {
     const electronPrompts: typeof electronPromptsContainer = globalThis.electronPrompts;
 
     const prompt: typeof window.prompt = (rawMessage, rawDefaultValue) => {
-      const message = String(rawMessage);
+      const message = rawMessage === undefined ? "" : String(rawMessage);
       const defaultValue = rawDefaultValue === undefined ? "" : String(rawDefaultValue);
 
       const result = electronPrompts.prompt(message, defaultValue);
       return result;
     };
-    const confirm: typeof window.confirm = (message) => {
-      void message;
-      return true;
+    const confirm: typeof window.confirm = (rawMessage) => {
+      const message = rawMessage === undefined ? "" : String(rawMessage);
+
+      const result = electronPrompts.confirm(message);
+      return result;
     };
-    const alert: typeof window.alert = (message) => {
-      void message;
-      return undefined;
+    const alert: typeof window.alert = (rawMessage) => {
+      const message = rawMessage === undefined ? "" : String(rawMessage);
+      const result = electronPrompts.alert(message);
+      return result;
     };
     window.prompt = prompt;
     window.confirm = confirm;

--- a/src/preload/prompts.ts
+++ b/src/preload/prompts.ts
@@ -1,0 +1,68 @@
+import { contextBridge, ipcRenderer } from "electron";
+
+/**
+ * Normalizes newlines in the given text.
+ * Based on the WHATWG Infra Standard: https://infra.spec.whatwg.org/#normalize-newlines
+ * @param text - The text to normalize.
+ * @returns The normalized text.
+ */
+function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+const MAX_DIALOG_STRING_LENGTH = 100;
+/**
+ * Optionally truncates a simple dialog string.
+ * Per the HTML spec, no UI should be provided to display the elided portion,
+ * as that could be exploited to craft deceptive security dialogs.
+ * https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#optionally-truncate-a-simple-dialog-string
+ * @param s - The dialog string to potentially truncate.
+ * @returns Either `s` itself, or a shorter string derived from `s`.
+ */
+function optionallyTruncate(s: string): string {
+  if (s.length <= MAX_DIALOG_STRING_LENGTH) return s;
+  return s.slice(0, MAX_DIALOG_STRING_LENGTH);
+}
+
+// Patches window.prompt, window.confirm, and window.alert to use custom dialogs
+export function tryPatchPrompts() {
+  // Validate and sanitize in here as main world cannot be trusted (websites can call globalThis.electronPrompts directly)
+  const electronPromptsContainer = {
+    prompt: (sourceMessage: string, sourceDefaultValue: string) => {
+      const message = optionallyTruncate(normalizeNewlines(String(sourceMessage)));
+      const defaultValue = optionallyTruncate(String(sourceDefaultValue));
+      return ipcRenderer.sendSync("prompts:prompt", message, defaultValue) as string | null;
+    }
+  };
+  contextBridge.exposeInMainWorld("electronPrompts", electronPromptsContainer);
+
+  // Executes in main world, must be self-contained!
+  const mainWorldScript = () => {
+    const electronPrompts: typeof electronPromptsContainer = globalThis.electronPrompts;
+
+    const prompt: typeof window.prompt = (rawMessage, rawDefaultValue) => {
+      const message = String(rawMessage);
+      const defaultValue = rawDefaultValue === undefined ? "" : String(rawDefaultValue);
+
+      const result = electronPrompts.prompt(message, defaultValue);
+      return result;
+    };
+    const confirm: typeof window.confirm = (message) => {
+      void message;
+      return true;
+    };
+    const alert: typeof window.alert = (message) => {
+      void message;
+      return undefined;
+    };
+    window.prompt = prompt;
+    window.confirm = confirm;
+    window.alert = alert;
+
+    delete globalThis.electronPrompts;
+  };
+
+  contextBridge.executeInMainWorld({
+    func: mainWorldScript
+  });
+}

--- a/src/renderer/src/components/browser-ui/main.tsx
+++ b/src/renderer/src/components/browser-ui/main.tsx
@@ -33,6 +33,7 @@ import { FindInPage } from "@/components/browser-ui/find-in-page";
 import { PasskeyConditionalUI } from "@/components/browser-ui/passkey-conditional-ui";
 import { WebPrompts } from "@/components/browser-ui/web-prompts";
 import { PasskeysRequestProvider } from "@/components/providers/passkeys-request-provider";
+import { ActivePromptsProvider } from "@/components/providers/active-prompts-provider";
 import { NavigationControls } from "@/components/browser-ui/browser-sidebar/_components/navigation-controls";
 import { AddressBar } from "@/components/browser-ui/browser-sidebar/_components/address-bar";
 import { SidebarWindowControlsMacOS } from "@/components/browser-ui/window-controls/macos";
@@ -336,8 +337,10 @@ export function BrowserUI({ type }: { type: BrowserUIType }) {
                   <BrowserActionProvider>
                     <ExtensionsProviderWithSpaces>
                       <PasskeysRequestProvider>
-                        <TabDisabler />
-                        <InternalBrowserUI isReady={isReady} type={type} />
+                        <ActivePromptsProvider>
+                          <TabDisabler />
+                          <InternalBrowserUI isReady={isReady} type={type} />
+                        </ActivePromptsProvider>
                       </PasskeysRequestProvider>
                     </ExtensionsProviderWithSpaces>
                   </BrowserActionProvider>

--- a/src/renderer/src/components/browser-ui/main.tsx
+++ b/src/renderer/src/components/browser-ui/main.tsx
@@ -31,6 +31,7 @@ import { PinnedTabsProvider } from "@/components/providers/pinned-tabs-provider"
 import BrowserContent from "@/components/browser-ui/browser-content";
 import { FindInPage } from "@/components/browser-ui/find-in-page";
 import { PasskeyConditionalUI } from "@/components/browser-ui/passkey-conditional-ui";
+import { WebPrompts } from "@/components/browser-ui/web-prompts";
 import { PasskeysRequestProvider } from "@/components/providers/passkeys-request-provider";
 import { NavigationControls } from "@/components/browser-ui/browser-sidebar/_components/navigation-controls";
 import { AddressBar } from "@/components/browser-ui/browser-sidebar/_components/address-bar";
@@ -282,6 +283,7 @@ function InternalBrowserUI({ isReady, type }: { isReady: boolean; type: BrowserU
                       {!hasSidebar && <PopupToolbar />}
                       <div className="relative flex-1 min-h-0 flex">
                         <div ref={browserContentAnchorRef} className="absolute inset-0 pointer-events-none" />
+                        <WebPrompts anchorRef={browserContentAnchorRef} />
                         <PasskeyConditionalUI anchorRef={browserContentAnchorRef} />
                         <FindInPage anchorRef={browserContentAnchorRef} />
                         <BrowserContent />

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useRef } from "react";
 import { PortalComponent } from "@/components/portal/portal";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { useFocusedTabId, useTabs } from "@/components/providers/tabs-provider";
@@ -10,23 +10,54 @@ import { Input } from "@/components/ui/input";
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ThemeProvider } from "@/components/main/theme";
+import { useActivePrompts } from "@/components/providers/active-prompts-provider";
+import type { ActivePrompt } from "~/types/prompts";
+import type { TabData } from "~/types/tabs";
 
 interface WebPromptsProps {
   anchorRef: React.RefObject<HTMLDivElement | null>;
 }
 
-function JavaScriptDialogCard() {
+function getOriginFromURL(url: string): string {
+  try {
+    const urlObject = new URL(url);
+    const protocol = urlObject.protocol.toLowerCase();
+    if (protocol === "http:" || protocol === "https:") {
+      return urlObject.hostname;
+    }
+    return urlObject.origin;
+  } catch {
+    return url;
+  }
+}
+
+function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabData }) {
+  const { type } = prompt;
+
+  const selectDefaultOnceRef = useRef(true);
   return (
     <Card className={cn("w-full max-w-md select-none gap-5", "border border-white/25", "shadow-2xl shadow-black/40")}>
       <CardHeader>
-        <CardTitle>{"www.youtube.com says"}</CardTitle>
+        <CardTitle>{`${getOriginFromURL(tab.url)} says`}</CardTitle>
       </CardHeader>
       <CardContent>
         <FieldGroup className="gap-5">
           <Field>
-            <FieldLabel htmlFor="prompt">Who are you?</FieldLabel>
-            <Input id="prompt" defaultValue="John Doe" />
+            <FieldLabel htmlFor="prompt">{prompt.message}</FieldLabel>
+            {type === "prompt" && (
+              <Input
+                id="prompt"
+                autoFocus
+                defaultValue={prompt.defaultValue}
+                onFocus={(e) => {
+                  if (!selectDefaultOnceRef.current) return;
+                  selectDefaultOnceRef.current = false;
+                  e.currentTarget.select();
+                }}
+              />
+            )}
           </Field>
+
           <Field orientation="horizontal">
             <Checkbox id="suppress-dialogs" name="suppress-dialogs" />
             <FieldLabel htmlFor="suppress-dialogs">Prevent this page from creating additional dialogs</FieldLabel>
@@ -34,10 +65,12 @@ function JavaScriptDialogCard() {
         </FieldGroup>
       </CardContent>
       <CardFooter className="justify-end flex-row gap-2">
-        <Button variant="outline" className="flex-1">
-          Cancel
-          <span className="text-xs text-muted-foreground">Esc</span>
-        </Button>
+        {(type === "prompt" || type === "confirm") && (
+          <Button variant="outline" className="flex-1">
+            Cancel
+            <span className="text-xs text-muted-foreground">Esc</span>
+          </Button>
+        )}
         <Button variant="default" className="flex-1">
           OK
           <span className="text-xs text-muted">↵</span>
@@ -49,10 +82,14 @@ function JavaScriptDialogCard() {
 
 const TabWebPrompt = memo(function TabWebPrompt({
   isVisible,
-  portalStyle
+  portalStyle,
+  prompt,
+  tab
 }: {
   isVisible: boolean;
   portalStyle: React.CSSProperties;
+  prompt: ActivePrompt;
+  tab: TabData;
 }) {
   return (
     <PortalComponent
@@ -64,7 +101,7 @@ const TabWebPrompt = memo(function TabWebPrompt({
     >
       <ThemeProvider>
         <div className={cn("w-full h-full", "bg-black/25 rounded-lg", "flex items-center justify-center")}>
-          <JavaScriptDialogCard />
+          <JavaScriptDialogCard prompt={prompt} tab={tab} />
         </div>
       </ThemeProvider>
     </PortalComponent>
@@ -78,6 +115,9 @@ export function WebPrompts({ anchorRef }: WebPromptsProps) {
 
   if (!tabsData || !anchorRect) return null;
 
+  const { activePrompts: allActivePrompts } = useActivePrompts();
+  const activePrompts = allActivePrompts.filter((prompt) => tabsData.tabs.some((tab) => tab.id === prompt.tabId));
+
   const portalStyle: React.CSSProperties = {
     top: anchorRect.y,
     left: anchorRect.x,
@@ -85,13 +125,23 @@ export function WebPrompts({ anchorRef }: WebPromptsProps) {
     height: anchorRect.height
   };
 
-  // return null;
-
   return (
     <>
-      {tabsData.tabs.map((tab) => (
-        <TabWebPrompt key={tab.id} isVisible={tab.id === focusedTabId} portalStyle={portalStyle} />
-      ))}
+      {activePrompts.map((prompt) => {
+        const tabId = prompt.tabId;
+        const tab = tabsData.tabs.find((tab) => tab.id === tabId);
+        if (!tab) return null;
+
+        return (
+          <TabWebPrompt
+            key={tabId}
+            isVisible={tabId === focusedTabId}
+            portalStyle={portalStyle}
+            prompt={prompt}
+            tab={tab}
+          />
+        );
+      })}
     </>
   );
 }

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { PortalComponent } from "@/components/portal/portal";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { useFocusedTabId, useTabs } from "@/components/providers/tabs-provider";
@@ -34,9 +34,67 @@ function getOriginFromURL(url: string): string {
 function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabData }) {
   const { type } = prompt;
 
+  const cardRef = useRef<HTMLDivElement>(null);
   const selectDefaultOnceRef = useRef(true);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const cancel = useCallback(() => {
+    switch (type) {
+      case "prompt":
+        flow.prompts.confirmPrompt(prompt.id, null);
+        break;
+      case "confirm":
+        flow.prompts.confirmPrompt(prompt.id, false);
+        break;
+      case "alert":
+        flow.prompts.confirmPrompt(prompt.id, undefined);
+        break;
+    }
+  }, [prompt.id]);
+
+  const confirm = useCallback(() => {
+    const value = inputRef.current?.value;
+    switch (type) {
+      case "prompt":
+        flow.prompts.confirmPrompt(prompt.id, value);
+        break;
+      case "confirm":
+        flow.prompts.confirmPrompt(prompt.id, true);
+        break;
+      case "alert":
+        flow.prompts.confirmPrompt(prompt.id, undefined);
+        break;
+    }
+  }, [prompt.id]);
+
+  useEffect(() => {
+    const card = cardRef.current;
+    if (!card) return;
+
+    const document = card.ownerDocument;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+
+      if (e.key === "Escape") {
+        cancel();
+      }
+      if (e.key === "Enter") {
+        confirm();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [confirm, cancel]);
+
   return (
-    <Card className={cn("w-full max-w-md select-none gap-5", "border border-white/25", "shadow-2xl shadow-black/40")}>
+    <Card
+      ref={cardRef}
+      className={cn("w-full max-w-md select-none gap-5", "border border-white/25", "shadow-2xl shadow-black/40")}
+    >
       <CardHeader>
         <CardTitle>{`${getOriginFromURL(tab.url)} says`}</CardTitle>
       </CardHeader>
@@ -44,12 +102,19 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
         <FieldGroup className="gap-5">
           {(type === "prompt" || prompt.message.trim()) && (
             <Field>
-              <FieldLabel htmlFor="prompt">{prompt.message.trim()}</FieldLabel>
+              {prompt.message.trim() && (
+                <div className="overflow-y-auto max-h-[30vh] custom-scrollbar">
+                  <FieldLabel htmlFor="prompt" className="whitespace-pre-line wrap-break-word min-w-0">
+                    {prompt.message.trim()}
+                  </FieldLabel>
+                </div>
+              )}
               {type === "prompt" && (
                 <Input
                   id="prompt"
                   autoFocus
                   defaultValue={prompt.defaultValue}
+                  ref={inputRef}
                   onFocus={(e) => {
                     if (!selectDefaultOnceRef.current) return;
                     selectDefaultOnceRef.current = false;
@@ -68,12 +133,12 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
       </CardContent>
       <CardFooter className="justify-end flex-row gap-2">
         {(type === "prompt" || type === "confirm") && (
-          <Button variant="outline" className="flex-1">
+          <Button variant="outline" className="flex-1" onClick={cancel}>
             Cancel
             <span className="text-xs text-muted-foreground">Esc</span>
           </Button>
         )}
-        <Button variant="default" className="flex-1">
+        <Button variant="default" className="flex-1" onClick={confirm}>
           OK
           <span className="text-xs text-muted">↵</span>
         </Button>

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -245,7 +245,7 @@ export function WebPrompts({ anchorRef }: WebPromptsProps) {
 
         return (
           <TabWebPrompt
-            key={tabId}
+            key={prompt.id}
             isVisible={tabId === focusedTabId}
             portalStyle={portalStyle}
             prompt={prompt}

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -30,42 +30,34 @@ function JavaScriptDialogCard({ prompt }: { prompt: ActivePrompt }) {
   const suppressionKey = prompt.suppressionKey;
   const [suppressChecked, setSuppressChecked] = useState(false);
 
-  const processSupression = useCallback(() => {
-    if (suppressChecked && suppressionKey) {
-      flow.prompts.suppressPrompt(suppressionKey);
-    }
-  }, [suppressionKey, suppressChecked]);
-
   const cancel = useCallback(() => {
     switch (type) {
       case "prompt":
-        flow.prompts.confirmPrompt(prompt.id, null);
+        flow.prompts.confirmPrompt(prompt.id, null, suppressChecked);
         break;
       case "confirm":
-        flow.prompts.confirmPrompt(prompt.id, false);
+        flow.prompts.confirmPrompt(prompt.id, false, suppressChecked);
         break;
       case "alert":
-        flow.prompts.confirmPrompt(prompt.id, undefined);
+        flow.prompts.confirmPrompt(prompt.id, undefined, suppressChecked);
         break;
     }
-    processSupression();
-  }, [type, prompt.id, processSupression]);
+  }, [type, prompt.id, suppressChecked]);
 
   const confirm = useCallback(() => {
     const value = inputRef.current?.value;
     switch (type) {
       case "prompt":
-        flow.prompts.confirmPrompt(prompt.id, value);
+        flow.prompts.confirmPrompt(prompt.id, value, suppressChecked);
         break;
       case "confirm":
-        flow.prompts.confirmPrompt(prompt.id, true);
+        flow.prompts.confirmPrompt(prompt.id, true, suppressChecked);
         break;
       case "alert":
-        flow.prompts.confirmPrompt(prompt.id, undefined);
+        flow.prompts.confirmPrompt(prompt.id, undefined, suppressChecked);
         break;
     }
-    processSupression();
-  }, [type, prompt.id, processSupression]);
+  }, [type, prompt.id, suppressChecked]);
 
   useEffect(() => {
     const card = cardRef.current;

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -1,0 +1,104 @@
+import { memo } from "react";
+import { PortalComponent } from "@/components/portal/portal";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { useFocusedTabId, useTabs } from "@/components/providers/tabs-provider";
+import { useBoundingRect } from "@/hooks/use-bounding-rect";
+import { cn } from "@/lib/utils";
+import { ViewLayer } from "~/layers";
+
+interface WebPromptsProps {
+  anchorRef: React.RefObject<HTMLDivElement | null>;
+}
+
+function JavaScriptDialogCard() {
+  return (
+    <Card
+      className={cn(
+        "w-full max-w-md gap-0 select-none",
+        "border border-white/25",
+        "bg-neutral-950/96 text-white",
+        "shadow-2xl shadow-black/40"
+      )}
+    >
+      <CardHeader className="pb-0">
+        <CardTitle className="text-lg text-white flex items-center">{"www.youtube.com says"}</CardTitle>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4">
+        <p className="text-sm leading-6 text-white/88">How old are you?</p>
+        <input
+          defaultValue="5"
+          autoFocus
+          className={cn(
+            "h-11 w-full rounded-lg border border-white/12 bg-white/8 px-4",
+            "text-sm text-white outline-none"
+          )}
+        />
+      </CardContent>
+
+      <CardFooter className="justify-end gap-2 mt-4">
+        <button
+          type="button"
+          className={cn(
+            "h-9 rounded-lg px-3 text-sm font-medium text-white/75",
+            "border border-white/12 bg-white/5 hover:bg-white/10 hover:text-white",
+            "transition-colors duration-150"
+          )}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className={cn(
+            "h-9 rounded-lg px-3 text-sm font-medium",
+            "bg-white text-black hover:bg-white/90",
+            "transition-colors duration-150"
+          )}
+        >
+          OK
+        </button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+const TabWebPrompt = memo(function TabWebPrompt({
+  isVisible,
+  portalStyle
+}: {
+  isVisible: boolean;
+  portalStyle: React.CSSProperties;
+}) {
+  return (
+    <PortalComponent visible={isVisible} autoFocus zIndex={ViewLayer.OVERLAY} className="fixed" style={portalStyle}>
+      <div className={cn("w-full h-full", "bg-black/25 rounded-lg", "flex items-center justify-center")}>
+        <JavaScriptDialogCard />
+      </div>
+    </PortalComponent>
+  );
+});
+
+export function WebPrompts({ anchorRef }: WebPromptsProps) {
+  const focusedTabId = useFocusedTabId();
+  const { tabsData } = useTabs();
+  const anchorRect = useBoundingRect(anchorRef);
+
+  if (!tabsData || !anchorRect) return null;
+
+  const portalStyle: React.CSSProperties = {
+    top: anchorRect.y,
+    left: anchorRect.x,
+    width: anchorRect.width,
+    height: anchorRect.height
+  };
+
+  // return null;
+
+  return (
+    <>
+      {tabsData.tabs.map((tab) => (
+        <TabWebPrompt key={tab.id} isVisible={tab.id === focusedTabId} portalStyle={portalStyle} />
+      ))}
+    </>
+  );
+}

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { PortalComponent } from "@/components/portal/portal";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { useFocusedTabId, useTabs } from "@/components/providers/tabs-provider";
@@ -13,6 +13,9 @@ import { ThemeProvider } from "@/components/main/theme";
 import { useActivePrompts } from "@/components/providers/active-prompts-provider";
 import type { ActivePrompt } from "~/types/prompts";
 import type { TabData } from "~/types/tabs";
+import { useMount } from "react-use";
+
+const supressedKeys = new Set<string>();
 
 interface WebPromptsProps {
   anchorRef: React.RefObject<HTMLDivElement | null>;
@@ -31,12 +34,33 @@ function getOriginFromURL(url: string): string {
   }
 }
 
-function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabData }) {
+function JavaScriptDialogCard({
+  prompt,
+  tab,
+  setShouldAutofocus
+}: {
+  prompt: ActivePrompt;
+  tab: TabData;
+  setShouldAutofocus: (shouldAutofocus: boolean) => void;
+}) {
   const { type } = prompt;
 
   const cardRef = useRef<HTMLDivElement>(null);
   const selectDefaultOnceRef = useRef(true);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const [tabStartingUrl] = useState(() => tab.url);
+
+  const supressionKey = `${prompt.tabId}-${getOriginFromURL(tabStartingUrl)}`;
+  const isSupressed = supressedKeys.has(supressionKey);
+  const [suppressChecked, setSuppressChecked] = useState(() => isSupressed);
+
+  const processSupression = useCallback(() => {
+    if (suppressChecked) {
+      supressedKeys.add(supressionKey);
+    } else {
+      supressedKeys.delete(supressionKey);
+    }
+  }, [supressionKey, suppressChecked]);
 
   const cancel = useCallback(() => {
     switch (type) {
@@ -50,7 +74,8 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
         flow.prompts.confirmPrompt(prompt.id, undefined);
         break;
     }
-  }, [type, prompt.id]);
+    processSupression();
+  }, [type, prompt.id, processSupression]);
 
   const confirm = useCallback(() => {
     const value = inputRef.current?.value;
@@ -65,7 +90,16 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
         flow.prompts.confirmPrompt(prompt.id, undefined);
         break;
     }
-  }, [type, prompt.id]);
+    processSupression();
+  }, [type, prompt.id, processSupression]);
+
+  useMount(() => {
+    if (isSupressed) {
+      cancel();
+    } else {
+      setShouldAutofocus(true);
+    }
+  });
 
   useEffect(() => {
     const card = cardRef.current;
@@ -96,7 +130,7 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
       className={cn("w-full max-w-md select-none gap-5", "border border-white/25", "shadow-2xl shadow-black/40")}
     >
       <CardHeader>
-        <CardTitle>{`${getOriginFromURL(tab.url)} says`}</CardTitle>
+        <CardTitle>{`${getOriginFromURL(tabStartingUrl)} says`}</CardTitle>
       </CardHeader>
       <CardContent>
         <FieldGroup className="gap-5">
@@ -125,10 +159,17 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
             </Field>
           )}
 
-          <Field orientation="horizontal">
-            <Checkbox id="suppress-dialogs" name="suppress-dialogs" />
-            <FieldLabel htmlFor="suppress-dialogs">Prevent this page from creating additional dialogs</FieldLabel>
-          </Field>
+          {(type === "prompt" || type === "confirm" || type === "alert") && (
+            <Field orientation="horizontal">
+              <Checkbox
+                id="suppress-dialogs"
+                name="suppress-dialogs"
+                defaultChecked={suppressChecked}
+                onCheckedChange={(checked) => (checked === true ? setSuppressChecked(true) : setSuppressChecked(false))}
+              />
+              <FieldLabel htmlFor="suppress-dialogs">Prevent this page from creating additional dialogs</FieldLabel>
+            </Field>
+          )}
         </FieldGroup>
       </CardContent>
       <CardFooter className="justify-end flex-row gap-2">
@@ -158,17 +199,19 @@ const TabWebPrompt = memo(function TabWebPrompt({
   prompt: ActivePrompt;
   tab: TabData;
 }) {
+  // don't autofocus on first render, if dialogs are suppressed we don't want the page to lose focus
+  const [shouldAutofocus, setShouldAutofocus] = useState(false);
   return (
     <PortalComponent
       visible={isVisible}
-      autoFocus
+      autoFocus={shouldAutofocus}
       zIndex={ViewLayer.OVERLAY_UNDER}
       className="fixed"
       style={portalStyle}
     >
       <ThemeProvider>
         <div className={cn("w-full h-full", "bg-black/25 rounded-lg", "flex items-center justify-center")}>
-          <JavaScriptDialogCard prompt={prompt} tab={tab} />
+          <JavaScriptDialogCard prompt={prompt} tab={tab} setShouldAutofocus={setShouldAutofocus} />
         </div>
       </ThemeProvider>
     </PortalComponent>

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -179,10 +179,10 @@ export function WebPrompts({ anchorRef }: WebPromptsProps) {
   const focusedTabId = useFocusedTabId();
   const { tabsData } = useTabs();
   const anchorRect = useBoundingRect(anchorRef);
+  const { activePrompts: allActivePrompts } = useActivePrompts();
 
   if (!tabsData || !anchorRect) return null;
 
-  const { activePrompts: allActivePrompts } = useActivePrompts();
   const activePrompts = allActivePrompts.filter((prompt) => tabsData.tabs.some((tab) => tab.id === prompt.tabId));
 
   const portalStyle: React.CSSProperties = {

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -50,7 +50,7 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
         flow.prompts.confirmPrompt(prompt.id, undefined);
         break;
     }
-  }, [prompt.id]);
+  }, [type, prompt.id]);
 
   const confirm = useCallback(() => {
     const value = inputRef.current?.value;
@@ -65,7 +65,7 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
         flow.prompts.confirmPrompt(prompt.id, undefined);
         break;
     }
-  }, [prompt.id]);
+  }, [type, prompt.id]);
 
   useEffect(() => {
     const card = cardRef.current;

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -42,21 +42,23 @@ function JavaScriptDialogCard({ prompt, tab }: { prompt: ActivePrompt; tab: TabD
       </CardHeader>
       <CardContent>
         <FieldGroup className="gap-5">
-          <Field>
-            <FieldLabel htmlFor="prompt">{prompt.message}</FieldLabel>
-            {type === "prompt" && (
-              <Input
-                id="prompt"
-                autoFocus
-                defaultValue={prompt.defaultValue}
-                onFocus={(e) => {
-                  if (!selectDefaultOnceRef.current) return;
-                  selectDefaultOnceRef.current = false;
-                  e.currentTarget.select();
-                }}
-              />
-            )}
-          </Field>
+          {(type === "prompt" || prompt.message.trim()) && (
+            <Field>
+              <FieldLabel htmlFor="prompt">{prompt.message.trim()}</FieldLabel>
+              {type === "prompt" && (
+                <Input
+                  id="prompt"
+                  autoFocus
+                  defaultValue={prompt.defaultValue}
+                  onFocus={(e) => {
+                    if (!selectDefaultOnceRef.current) return;
+                    selectDefaultOnceRef.current = false;
+                    e.currentTarget.select();
+                  }}
+                />
+              )}
+            </Field>
+          )}
 
           <Field orientation="horizontal">
             <Checkbox id="suppress-dialogs" name="suppress-dialogs" />

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -36,9 +36,11 @@ function JavaScriptDialogCard() {
       <CardFooter className="justify-end flex-row gap-2">
         <Button variant="outline" className="flex-1">
           Cancel
+          <span className="text-xs text-muted-foreground">Esc</span>
         </Button>
         <Button variant="default" className="flex-1">
           OK
+          <span className="text-xs text-muted">↵</span>
         </Button>
       </CardFooter>
     </Card>

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -5,6 +5,11 @@ import { useFocusedTabId, useTabs } from "@/components/providers/tabs-provider";
 import { useBoundingRect } from "@/hooks/use-bounding-rect";
 import { cn } from "@/lib/utils";
 import { ViewLayer } from "~/layers";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ThemeProvider } from "@/components/main/theme";
 
 interface WebPromptsProps {
   anchorRef: React.RefObject<HTMLDivElement | null>;
@@ -12,51 +17,29 @@ interface WebPromptsProps {
 
 function JavaScriptDialogCard() {
   return (
-    <Card
-      className={cn(
-        "w-full max-w-md gap-0 select-none",
-        "border border-white/25",
-        "bg-neutral-950/96 text-white",
-        "shadow-2xl shadow-black/40"
-      )}
-    >
-      <CardHeader className="pb-0">
-        <CardTitle className="text-lg text-white flex items-center">{"www.youtube.com says"}</CardTitle>
+    <Card className={cn("w-full max-w-md select-none gap-5", "border border-white/25", "shadow-2xl shadow-black/40")}>
+      <CardHeader>
+        <CardTitle>{"www.youtube.com says"}</CardTitle>
       </CardHeader>
-
-      <CardContent className="flex flex-col gap-4">
-        <p className="text-sm leading-6 text-white/88">How old are you?</p>
-        <input
-          defaultValue="5"
-          autoFocus
-          className={cn(
-            "h-11 w-full rounded-lg border border-white/12 bg-white/8 px-4",
-            "text-sm text-white outline-none"
-          )}
-        />
+      <CardContent>
+        <FieldGroup className="gap-5">
+          <Field>
+            <FieldLabel htmlFor="prompt">Who are you?</FieldLabel>
+            <Input id="prompt" defaultValue="John Doe" />
+          </Field>
+          <Field orientation="horizontal">
+            <Checkbox id="suppress-dialogs" name="suppress-dialogs" />
+            <FieldLabel htmlFor="suppress-dialogs">Prevent this page from creating additional dialogs</FieldLabel>
+          </Field>
+        </FieldGroup>
       </CardContent>
-
-      <CardFooter className="justify-end gap-2 mt-4">
-        <button
-          type="button"
-          className={cn(
-            "h-9 rounded-lg px-3 text-sm font-medium text-white/75",
-            "border border-white/12 bg-white/5 hover:bg-white/10 hover:text-white",
-            "transition-colors duration-150"
-          )}
-        >
+      <CardFooter className="justify-end flex-row gap-2">
+        <Button variant="outline" className="flex-1">
           Cancel
-        </button>
-        <button
-          type="button"
-          className={cn(
-            "h-9 rounded-lg px-3 text-sm font-medium",
-            "bg-white text-black hover:bg-white/90",
-            "transition-colors duration-150"
-          )}
-        >
+        </Button>
+        <Button variant="default" className="flex-1">
           OK
-        </button>
+        </Button>
       </CardFooter>
     </Card>
   );
@@ -71,9 +54,11 @@ const TabWebPrompt = memo(function TabWebPrompt({
 }) {
   return (
     <PortalComponent visible={isVisible} autoFocus zIndex={ViewLayer.OVERLAY} className="fixed" style={portalStyle}>
-      <div className={cn("w-full h-full", "bg-black/25 rounded-lg", "flex items-center justify-center")}>
-        <JavaScriptDialogCard />
-      </div>
+      <ThemeProvider>
+        <div className={cn("w-full h-full", "bg-black/25 rounded-lg", "flex items-center justify-center")}>
+          <JavaScriptDialogCard />
+        </div>
+      </ThemeProvider>
     </PortalComponent>
   );
 });

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -37,11 +37,11 @@ function getOriginFromURL(url: string): string {
 function JavaScriptDialogCard({
   prompt,
   tab,
-  setShouldAutofocus
+  setIsReady
 }: {
   prompt: ActivePrompt;
   tab: TabData;
-  setShouldAutofocus: (shouldAutofocus: boolean) => void;
+  setIsReady: (isReady: boolean) => void;
 }) {
   const { type } = prompt;
 
@@ -97,7 +97,7 @@ function JavaScriptDialogCard({
     if (isSupressed) {
       cancel();
     } else {
-      setShouldAutofocus(true);
+      setIsReady(true);
     }
   });
 
@@ -199,19 +199,20 @@ const TabWebPrompt = memo(function TabWebPrompt({
   prompt: ActivePrompt;
   tab: TabData;
 }) {
-  // don't autofocus on first render, if dialogs are suppressed we don't want the page to lose focus
-  const [shouldAutofocus, setShouldAutofocus] = useState(false);
+  // don't show the dialog on first render, if dialogs are suppressed we don't want the page to lose focus
+  const [isReady, setIsReady] = useState(false);
+
   return (
     <PortalComponent
-      visible={isVisible}
-      autoFocus={shouldAutofocus}
+      visible={isVisible && isReady}
+      autoFocus={isReady}
       zIndex={ViewLayer.OVERLAY_UNDER}
       className="fixed"
       style={portalStyle}
     >
       <ThemeProvider>
         <div className={cn("w-full h-full", "bg-black/25 rounded-lg", "flex items-center justify-center")}>
-          <JavaScriptDialogCard prompt={prompt} tab={tab} setShouldAutofocus={setShouldAutofocus} />
+          <JavaScriptDialogCard prompt={prompt} tab={tab} setIsReady={setIsReady} />
         </div>
       </ThemeProvider>
     </PortalComponent>

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -55,7 +55,13 @@ const TabWebPrompt = memo(function TabWebPrompt({
   portalStyle: React.CSSProperties;
 }) {
   return (
-    <PortalComponent visible={isVisible} autoFocus zIndex={ViewLayer.OVERLAY} className="fixed" style={portalStyle}>
+    <PortalComponent
+      visible={isVisible}
+      autoFocus
+      zIndex={ViewLayer.OVERLAY_UNDER}
+      className="fixed"
+      style={portalStyle}
+    >
       <ThemeProvider>
         <div className={cn("w-full h-full", "bg-black/25 rounded-lg", "flex items-center justify-center")}>
           <JavaScriptDialogCard />

--- a/src/renderer/src/components/browser-ui/web-prompts.tsx
+++ b/src/renderer/src/components/browser-ui/web-prompts.tsx
@@ -12,55 +12,29 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { ThemeProvider } from "@/components/main/theme";
 import { useActivePrompts } from "@/components/providers/active-prompts-provider";
 import type { ActivePrompt } from "~/types/prompts";
-import type { TabData } from "~/types/tabs";
-import { useMount } from "react-use";
+import { getOriginFromURL } from "~/utility";
 
-const supressedKeys = new Set<string>();
+const suppressablePromptTypes = ["prompt", "confirm", "alert"] as const satisfies ActivePrompt["type"][];
 
 interface WebPromptsProps {
   anchorRef: React.RefObject<HTMLDivElement | null>;
 }
 
-function getOriginFromURL(url: string): string {
-  try {
-    const urlObject = new URL(url);
-    const protocol = urlObject.protocol.toLowerCase();
-    if (protocol === "http:" || protocol === "https:") {
-      return urlObject.hostname;
-    }
-    return urlObject.origin;
-  } catch {
-    return url;
-  }
-}
-
-function JavaScriptDialogCard({
-  prompt,
-  tab,
-  setIsReady
-}: {
-  prompt: ActivePrompt;
-  tab: TabData;
-  setIsReady: (isReady: boolean) => void;
-}) {
+function JavaScriptDialogCard({ prompt }: { prompt: ActivePrompt }) {
   const { type } = prompt;
 
   const cardRef = useRef<HTMLDivElement>(null);
   const selectDefaultOnceRef = useRef(true);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [tabStartingUrl] = useState(() => tab.url);
 
-  const supressionKey = `${prompt.tabId}-${getOriginFromURL(tabStartingUrl)}`;
-  const isSupressed = supressedKeys.has(supressionKey);
-  const [suppressChecked, setSuppressChecked] = useState(() => isSupressed);
+  const suppressionKey = prompt.suppressionKey;
+  const [suppressChecked, setSuppressChecked] = useState(false);
 
   const processSupression = useCallback(() => {
-    if (suppressChecked) {
-      supressedKeys.add(supressionKey);
-    } else {
-      supressedKeys.delete(supressionKey);
+    if (suppressChecked && suppressionKey) {
+      flow.prompts.suppressPrompt(suppressionKey);
     }
-  }, [supressionKey, suppressChecked]);
+  }, [suppressionKey, suppressChecked]);
 
   const cancel = useCallback(() => {
     switch (type) {
@@ -93,14 +67,6 @@ function JavaScriptDialogCard({
     processSupression();
   }, [type, prompt.id, processSupression]);
 
-  useMount(() => {
-    if (isSupressed) {
-      cancel();
-    } else {
-      setIsReady(true);
-    }
-  });
-
   useEffect(() => {
     const card = cardRef.current;
     if (!card) return;
@@ -130,7 +96,7 @@ function JavaScriptDialogCard({
       className={cn("w-full max-w-md select-none gap-5", "border border-white/25", "shadow-2xl shadow-black/40")}
     >
       <CardHeader>
-        <CardTitle>{`${getOriginFromURL(tabStartingUrl)} says`}</CardTitle>
+        <CardTitle>{`${prompt.originUrl ? getOriginFromURL(prompt.originUrl) : "Unknown website"} says`}</CardTitle>
       </CardHeader>
       <CardContent>
         <FieldGroup className="gap-5">
@@ -159,7 +125,7 @@ function JavaScriptDialogCard({
             </Field>
           )}
 
-          {(type === "prompt" || type === "confirm" || type === "alert") && (
+          {suppressablePromptTypes.includes(type) && suppressionKey && (
             <Field orientation="horizontal">
               <Checkbox
                 id="suppress-dialogs"
@@ -191,28 +157,23 @@ function JavaScriptDialogCard({
 const TabWebPrompt = memo(function TabWebPrompt({
   isVisible,
   portalStyle,
-  prompt,
-  tab
+  prompt
 }: {
   isVisible: boolean;
   portalStyle: React.CSSProperties;
   prompt: ActivePrompt;
-  tab: TabData;
 }) {
-  // don't show the dialog on first render, if dialogs are suppressed we don't want the page to lose focus
-  const [isReady, setIsReady] = useState(false);
-
   return (
     <PortalComponent
-      visible={isVisible && isReady}
-      autoFocus={isReady}
+      visible={isVisible}
+      autoFocus
       zIndex={ViewLayer.OVERLAY_UNDER}
       className="fixed"
       style={portalStyle}
     >
       <ThemeProvider>
         <div className={cn("w-full h-full", "bg-black/25 rounded-lg", "flex items-center justify-center")}>
-          <JavaScriptDialogCard prompt={prompt} tab={tab} setIsReady={setIsReady} />
+          <JavaScriptDialogCard prompt={prompt} />
         </div>
       </ThemeProvider>
     </PortalComponent>
@@ -240,17 +201,8 @@ export function WebPrompts({ anchorRef }: WebPromptsProps) {
     <>
       {activePrompts.map((prompt) => {
         const tabId = prompt.tabId;
-        const tab = tabsData.tabs.find((tab) => tab.id === tabId);
-        if (!tab) return null;
-
         return (
-          <TabWebPrompt
-            key={prompt.id}
-            isVisible={tabId === focusedTabId}
-            portalStyle={portalStyle}
-            prompt={prompt}
-            tab={tab}
-          />
+          <TabWebPrompt key={prompt.id} isVisible={tabId === focusedTabId} portalStyle={portalStyle} prompt={prompt} />
         );
       })}
     </>

--- a/src/renderer/src/components/providers/active-prompts-provider.tsx
+++ b/src/renderer/src/components/providers/active-prompts-provider.tsx
@@ -1,0 +1,41 @@
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import type { ActivePrompt } from "~/types/prompts";
+
+interface ActivePromptsContextValue {
+  activePrompts: ActivePrompt[];
+}
+
+const ActivePromptsContext = createContext<ActivePromptsContextValue | null>(null);
+
+export function useActivePrompts() {
+  const context = useContext(ActivePromptsContext);
+  if (!context) {
+    throw new Error("useActivePrompts must be used within a ActivePromptsProvider");
+  }
+  return context;
+}
+
+interface ActivePromptsProviderProps {
+  children: React.ReactNode;
+}
+
+export function ActivePromptsProvider({ children }: ActivePromptsProviderProps) {
+  const [activePrompts, setActivePrompts] = useState<ActivePrompt[]>([]);
+
+  const fetchActivePrompts = useCallback(async () => {
+    const prompts = await flow.prompts.getActivePrompts();
+    setActivePrompts(prompts);
+  }, []);
+
+  useEffect(() => {
+    fetchActivePrompts();
+
+    const unsub = flow.prompts.onActivePromptsChanged((prompts) => {
+      setActivePrompts(prompts);
+    });
+
+    return () => unsub();
+  }, [fetchActivePrompts]);
+
+  return <ActivePromptsContext.Provider value={{ activePrompts }}>{children}</ActivePromptsContext.Provider>;
+}

--- a/src/renderer/src/components/ui/checkbox.tsx
+++ b/src/renderer/src/components/ui/checkbox.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { CheckIcon } from "lucide-react";
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/renderer/src/components/ui/field.tsx
+++ b/src/renderer/src/components/ui/field.tsx
@@ -1,0 +1,224 @@
+import { useMemo } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6",
+        "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn("mb-3 font-medium", "data-[variant=legend]:text-base", "data-[variant=label]:text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+const fieldVariants = cva("group/field flex w-full gap-3 data-[invalid=true]:text-destructive", {
+  variants: {
+    orientation: {
+      vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
+      horizontal: [
+        "flex-row items-center",
+        "[&>[data-slot=field-label]]:flex-auto",
+        "has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px"
+      ],
+      responsive: [
+        "flex-col @md/field-group:flex-row @md/field-group:items-center [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto",
+        "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
+        "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px"
+      ]
+    }
+  },
+  defaultVariants: {
+    orientation: "vertical"
+  }
+});
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn("group/field-content flex flex-1 flex-col gap-1.5 leading-snug", className)}
+      {...props}
+    />
+  );
+}
+
+function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
+        "has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-sm leading-normal font-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn("relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2", className)}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>;
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children;
+    }
+
+    if (!errors?.length) {
+      return null;
+    }
+
+    const uniqueErrors = [...new Map(errors.map((error) => [error?.message, error])).values()];
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message;
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+      </ul>
+    );
+  }, [children, errors]);
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle
+};

--- a/src/shared/flow/flow.ts
+++ b/src/shared/flow/flow.ts
@@ -13,6 +13,7 @@ import { FlowNewTabAPI } from "~/flow/interfaces/browser/newTab";
 import { FlowFindInPageAPI } from "~/flow/interfaces/browser/find-in-page";
 import { FlowHistoryAPI } from "~/flow/interfaces/browser/history";
 import { FlowPasskeyAPI } from "~/flow/interfaces/browser/passkey";
+import { FlowPromptsAPI } from "~/flow/interfaces/browser/prompts";
 
 import { FlowProfilesAPI } from "~/flow/interfaces/sessions/profiles";
 import { FlowSpacesAPI } from "~/flow/interfaces/sessions/spaces";
@@ -51,6 +52,7 @@ declare global {
     omnibox: FlowOmniboxAPI;
     newTab: FlowNewTabAPI;
     findInPage: FlowFindInPageAPI;
+    prompts: FlowPromptsAPI;
 
     // Session APIs
     profiles: FlowProfilesAPI;

--- a/src/shared/flow/interfaces/browser/prompts.ts
+++ b/src/shared/flow/interfaces/browser/prompts.ts
@@ -1,0 +1,17 @@
+import { IPCListener } from "~/flow/types";
+import { ActivePrompt } from "~/types/prompts";
+
+export interface FlowPromptsAPI {
+  /**
+   * Get all currently pending conditional passkey requests.
+   * @returns Array of pending conditional passkey requests
+   */
+  getActivePrompts: () => Promise<ActivePrompt[]>;
+
+  /**
+   * Subscribe to changes in the list of conditional passkey requests.
+   * Fires whenever a request is added, updated, or removed.
+   * @param callback Receives the full updated list of requests
+   */
+  onActivePromptsChanged: IPCListener<[ActivePrompt[]]>;
+}

--- a/src/shared/flow/interfaces/browser/prompts.ts
+++ b/src/shared/flow/interfaces/browser/prompts.ts
@@ -22,11 +22,5 @@ export interface FlowPromptsAPI {
    * @param promptId The ID of the prompt to confirm
    * @param result The result of the prompt
    */
-  confirmPrompt: (promptId: string, result: any) => void;
-
-  /**
-   * Suppress a prompt.
-   * @param suppressionKey The key to suppress the prompt by
-   */
-  suppressPrompt: (suppressionKey: string) => void;
+  confirmPrompt: (promptId: string, result: any, suppress: boolean) => void;
 }

--- a/src/shared/flow/interfaces/browser/prompts.ts
+++ b/src/shared/flow/interfaces/browser/prompts.ts
@@ -5,15 +5,15 @@ import { ActivePrompt } from "~/types/prompts";
 
 export interface FlowPromptsAPI {
   /**
-   * Get all currently pending conditional passkey requests.
-   * @returns Array of pending conditional passkey requests
+   * Get all currently pending prompts.
+   * @returns Array of pending prompts
    */
   getActivePrompts: () => Promise<ActivePrompt[]>;
 
   /**
-   * Subscribe to changes in the list of conditional passkey requests.
-   * Fires whenever a request is added, updated, or removed.
-   * @param callback Receives the full updated list of requests
+   * Subscribe to changes in the list of prompts.
+   * Fires whenever a prompt is added, updated, or removed.
+   * @param callback Receives the full updated list of prompts
    */
   onActivePromptsChanged: IPCListener<[ActivePrompt[]]>;
 

--- a/src/shared/flow/interfaces/browser/prompts.ts
+++ b/src/shared/flow/interfaces/browser/prompts.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { IPCListener } from "~/flow/types";
 import { ActivePrompt } from "~/types/prompts";
 
@@ -14,4 +16,11 @@ export interface FlowPromptsAPI {
    * @param callback Receives the full updated list of requests
    */
   onActivePromptsChanged: IPCListener<[ActivePrompt[]]>;
+
+  /**
+   * Confirm a prompt.
+   * @param promptId The ID of the prompt to confirm
+   * @param result The result of the prompt
+   */
+  confirmPrompt: (promptId: string, result: any) => void;
 }

--- a/src/shared/flow/interfaces/browser/prompts.ts
+++ b/src/shared/flow/interfaces/browser/prompts.ts
@@ -23,4 +23,10 @@ export interface FlowPromptsAPI {
    * @param result The result of the prompt
    */
   confirmPrompt: (promptId: string, result: any) => void;
+
+  /**
+   * Suppress a prompt.
+   * @param suppressionKey The key to suppress the prompt by
+   */
+  suppressPrompt: (suppressionKey: string) => void;
 }

--- a/src/shared/layers.ts
+++ b/src/shared/layers.ts
@@ -21,10 +21,13 @@ export const ViewLayer = {
   /** Glance mode: the foreground tab, rendered on top of the back tab */
   TAB_FRONT: 20,
 
+  /** Overlay, but would block the content area and should be rendered under overlays. */
+  OVERLAY_UNDER: 30,
+
   /** Portal component windows: floating sidebar, toasts, extension popups.
       These are WebContentsViews that render browser chrome UI on top of
       tab content. */
-  OVERLAY: 30,
+  OVERLAY: 31,
 
   /** Portal popovers: context menus, dropdowns anchored to overlay content.
       Must be above OVERLAY so a popover triggered from a portal renders

--- a/src/shared/types/prompts.ts
+++ b/src/shared/types/prompts.ts
@@ -1,3 +1,7 @@
+/** `Omit<T, K>` on a union uses `keyof T` as key intersection; omit each member instead. */
+type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never;
+
+// Prompt Result Types //
 interface SuccessfulPromptResult<Result> {
   success: true;
   result: Result;
@@ -10,13 +14,11 @@ interface FailedPromptResult {
 export type PromptResult<Result> = SuccessfulPromptResult<Result> | FailedPromptResult;
 
 // Extendable Prompt States //
-type NormalOrPromise<T> = T | PromiseLike<T>;
-
 interface BasePromptState<Result> {
   id: string;
   tabId: number;
   promise: Promise<PromptResult<Result>>;
-  resolver: (value: NormalOrPromise<PromptResult<Result>>) => void;
+  resolver: (value: PromptResult<Result>) => void;
 }
 
 // Main Prompt States //
@@ -26,5 +28,18 @@ interface TextPromptState extends BasePromptState<string | null> {
   defaultValue: string;
 }
 
+interface ConfirmPromptState extends BasePromptState<boolean> {
+  type: "confirm";
+  message: string;
+}
+
+interface AlertPromptState extends BasePromptState<void> {
+  type: "alert";
+  message: string;
+}
+
 // Combined Prompt States //
-export type PromptState = TextPromptState;
+export type PromptState = TextPromptState | ConfirmPromptState | AlertPromptState;
+
+// Renderer Types //
+export type ActivePrompt = DistributiveOmit<PromptState, "promise" | "resolver">;

--- a/src/shared/types/prompts.ts
+++ b/src/shared/types/prompts.ts
@@ -15,6 +15,7 @@ type NormalOrPromise<T> = T | PromiseLike<T>;
 interface BasePromptState<Result> {
   id: string;
   tabId: number;
+  promise: Promise<PromptResult<Result>>;
   resolver: (value: NormalOrPromise<PromptResult<Result>>) => void;
 }
 

--- a/src/shared/types/prompts.ts
+++ b/src/shared/types/prompts.ts
@@ -1,0 +1,29 @@
+interface SuccessfulPromptResult<Result> {
+  success: true;
+  result: Result;
+}
+
+interface FailedPromptResult {
+  success: false;
+}
+
+export type PromptResult<Result> = SuccessfulPromptResult<Result> | FailedPromptResult;
+
+// Extendable Prompt States //
+type NormalOrPromise<T> = T | PromiseLike<T>;
+
+interface BasePromptState<Result> {
+  id: string;
+  tabId: number;
+  resolver: (value: NormalOrPromise<PromptResult<Result>>) => void;
+}
+
+// Main Prompt States //
+interface TextPromptState extends BasePromptState<string | null> {
+  type: "prompt";
+  message: string;
+  defaultValue: string;
+}
+
+// Combined Prompt States //
+export type PromptState = TextPromptState;

--- a/src/shared/types/prompts.ts
+++ b/src/shared/types/prompts.ts
@@ -1,5 +1,4 @@
-/** `Omit<T, K>` on a union uses `keyof T` as key intersection; omit each member instead. */
-type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never;
+import type { DistributiveOmit } from "./utils";
 
 // Prompt Result Types //
 interface SuccessfulPromptResult<Result> {

--- a/src/shared/types/prompts.ts
+++ b/src/shared/types/prompts.ts
@@ -16,6 +16,10 @@ export type PromptResult<Result> = SuccessfulPromptResult<Result> | FailedPrompt
 interface BasePromptState<Result> {
   id: string;
   tabId: number;
+  originUrl?: string;
+  suppressionKey?: string;
+
+  // Promise and Resolver //
   promise: Promise<PromptResult<Result>>;
   resolver: (value: PromptResult<Result>) => void;
 }

--- a/src/shared/types/utils.ts
+++ b/src/shared/types/utils.ts
@@ -1,0 +1,2 @@
+/** `Omit<T, K>` on a union uses `keyof T` as key intersection; omit each member instead. */
+export type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never;

--- a/src/shared/utility.ts
+++ b/src/shared/utility.ts
@@ -1,0 +1,12 @@
+export function getOriginFromURL(url: string): string {
+  try {
+    const urlObject = new URL(url);
+    const protocol = urlObject.protocol.toLowerCase();
+    if (protocol === "http:" || protocol === "https:") {
+      return urlObject.hostname;
+    }
+    return urlObject.origin;
+  } catch {
+    return url;
+  }
+}


### PR DESCRIPTION
- add support for `window.prompt()`, `window.alert()` and `window.confirm()` according to web specifications
- using portals in browser UI, paint an overlay on top of the tab to show the prompts
- added hotkeys to confirm and cancel the prompts
- added prompt manager in main thread to ensure only one prompt per tab at a time
- browser UI map to suppress dialogs for this tab on this origin.
- added OVERLAY_UNDER z-index to show under other overlays
- cancel prompts on frame detach
- wired up with browser UI, main process and tab's preloads (and its iframes)
- `flow.prompts.*` APIs for browser UI
- groundwork done for other prompts in the future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-page JavaScript dialogs (alert/confirm/prompt) with keyboard shortcuts, text input for prompt, tab-aware presentation, suppression option, and a browser-facing prompts API to list/subscribe to active prompts and confirm results.
  * UI primitives added: checkbox and field components; provider integration for prompt state and dialog rendering.

* **Chores**
  * Adjusted overlay stacking to improve prompt layering.

* **Dependencies**
  * Bumped Radix UI dev dependency to v1.4.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->