### PR TITLE
Save Theme Button After Change Won't Work

### DIFF
--- a/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
+++ b/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, Loader2, Save, Settings, Trash2, PaintBucket, Check } from "lucide-react";
 import type { Space } from "~/flow/interfaces/sessions/spaces";
@@ -23,10 +23,17 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  // Tracks the latest saveSuccess value for the auto-close timeout below,
+  // since a setTimeout closure only ever sees the state at the time it was scheduled.
+  const saveSuccessRef = useRef(false);
 
   // Update edited space
   const updateEditedSpace = (updates: Partial<Space>) => {
     setEditedSpace((prev) => ({ ...prev, ...updates }));
+    // A fresh edit invalidates the previous "Saved" confirmation so the Save
+    // button becomes clickable again instead of staying stuck on "Saved".
+    saveSuccessRef.current = false;
+    setSaveSuccess(false);
   };
 
   // Handle space update
@@ -58,11 +65,12 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
 
         await flow.spaces.updateSpace(space.profileId, space.id, updatedFields);
         onSpacesUpdate(); // Refetch spaces after successful update
+        saveSuccessRef.current = true;
         setSaveSuccess(true);
 
-        // Auto-close after short delay
+        // Auto-close after short delay, unless the user started editing again in the meantime
         setTimeout(() => {
-          if (saveSuccess) {
+          if (saveSuccessRef.current) {
             onClose();
           }
         }, 1500);
@@ -97,6 +105,9 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
       ...editedSpace,
       name: e.target.value
     });
+    // See updateEditedSpace: a fresh edit should re-enable the Save button.
+    saveSuccessRef.current = false;
+    setSaveSuccess(false);
   };
 
   // Detect if there are unsaved changes

--- a/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
+++ b/src/renderer/src/components/settings/sections/spaces/space-editor.tsx
@@ -23,16 +23,16 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  // Tracks the latest saveSuccess value for the auto-close timeout below,
-  // since a setTimeout closure only ever sees the state at the time it was scheduled.
-  const saveSuccessRef = useRef(false);
+  // Tracks the current edit generation to prevent old save timeouts from closing the editor
+  // if the user makes a new edit or triggers a new save before the timeout fires.
+  const editGenerationRef = useRef(0);
 
   // Update edited space
   const updateEditedSpace = (updates: Partial<Space>) => {
     setEditedSpace((prev) => ({ ...prev, ...updates }));
     // A fresh edit invalidates the previous "Saved" confirmation so the Save
     // button becomes clickable again instead of staying stuck on "Saved".
-    saveSuccessRef.current = false;
+    editGenerationRef.current += 1;
     setSaveSuccess(false);
   };
 
@@ -40,6 +40,8 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
   const handleSave = async () => {
     setIsSaving(true);
     setSaveSuccess(false);
+    const capturedGeneration = editGenerationRef.current;
+
     try {
       // Only send the fields that have changed
       const updatedFields: Partial<Space> = {};
@@ -65,15 +67,17 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
 
         await flow.spaces.updateSpace(space.profileId, space.id, updatedFields);
         onSpacesUpdate(); // Refetch spaces after successful update
-        saveSuccessRef.current = true;
-        setSaveSuccess(true);
+        
+        if (editGenerationRef.current === capturedGeneration) {
+          setSaveSuccess(true);
 
-        // Auto-close after short delay, unless the user started editing again in the meantime
-        setTimeout(() => {
-          if (saveSuccessRef.current) {
-            onClose();
-          }
-        }, 1500);
+          // Auto-close after short delay, unless the user started editing again in the meantime
+          setTimeout(() => {
+            if (editGenerationRef.current === capturedGeneration) {
+              onClose();
+            }
+          }, 1500);
+        }
       } else {
         // No changes to save
         onClose();
@@ -106,7 +110,7 @@ export function SpaceEditor({ space, onClose, onDelete, onSpacesUpdate }: SpaceE
       name: e.target.value
     });
     // See updateEditedSpace: a fresh edit should re-enable the Save button.
-    saveSuccessRef.current = false;
+    editGenerationRef.current += 1;
     setSaveSuccess(false);
   };
 


### PR DESCRIPTION
Fixes #281

Save button got stuck as a static 'Saved' confirmation because the auto-close timeout checked a stale closure of saveSuccess (always false, so it never fired) and no code cleared saveSuccess on subsequent edits; fixed by tracking success in a ref for the timeout and resetting saveSuccess whenever the user edits the space again.

**Testing:** Repo has no test suite (confirmed no test files/dirs); verified by tracing the exact stale-closure bug against the reported repro steps and confirming the edited file still parses/formats cleanly via npx prettier --check (no syntax errors) -- did not run bun install/full typecheck as it was not needed to validate this narrow logic fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editing and saving behavior in the space editor.
  * Editing any field, including the name, now correctly resets the save-success state.
  * Prevented previous success notifications from closing the editor after new changes are made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->